### PR TITLE
37: kernel convolution

### DIFF
--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -194,7 +194,7 @@ export function findTile(tiles) {
  * height: the height of the initialized 2D array
  * defaultVal: the value to give each element in the initialized 2D array
  */
-export function init2dArray(width, height, defaultVal = 0) {
+export function init2dArray(width, height, defaultVal) {
   const matrix = [];
 
   for (let x = 0; x < width; x++) {
@@ -265,7 +265,7 @@ export function addBufferTo2dArray(m, bufSize) {
   const mWithBufHeight = mHeight + (bufSize * 2);
 
   // Create a grid with matrix's values and a bufSize perimeter of zeros
-  const mWithBuf = init2dArray(mWithBufWidth, mWithBufHeight);
+  const mWithBuf = init2dArray(mWithBufWidth, mWithBufHeight, 0);
 
   // Add the buffer
   for (let x = 0; x < mWithBufWidth; x++) {

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -232,3 +232,81 @@ export function multiplyCorrespondingElementsAndSum(m1, m2) {
 
   return sum;
 }
+
+
+/* Returns a matrix with a buffer applied around its perimeter. Example:
+ *   Take the element values in the corners of the matrix and apply them
+ *   as a bufSize by bufSize matrix to the new corners
+ *   Example:
+ *     m = 1 2 3   bufSize = 2   mWithBuf = 1 1       3 3
+ *         4 5 6                            1 1       3 3
+ *         7 8 9                                1 2 3
+ *                                              4 5 6
+ *                                              7 8 9
+ *                                          7 7       9 9
+ *                                          7 7       9 9
+ *   Take the element values on the edges of the matrix and apply them as
+ *   rows/columns that are bufSize long to the new edges
+ *     mWithBuf = 1 1       3 3   bufSize = 2  mWithBuf = 1 1 1 2 3 3 3
+ *                1 1       3 3                           1 1 1 2 3 3 3
+ *                    1 2 3                               1 1 1 2 3 3 3
+ *                    4 5 6                               4 4 4 5 6 6 6
+ *                    7 8 9                               7 7 7 8 9 9 9
+ *                7 7       9 9                           7 7 7 8 9 9 9
+ *                7 7       9 9                           7 7 7 8 9 9 9
+ *
+ * m: a 2D array, which will have a buffer added around its perimeter
+ * bufSize: the size of buffer to add around the matrix
+ */
+export function addBufferTo2dArray(m, bufSize) {
+  const mWidth = m.length;
+  const mHeight = m[0].length;
+  const mWithBufWidth = mWidth + (bufSize * 2);
+  const mWithBufHeight = mHeight + (bufSize * 2);
+
+  // Create a grid with matrix's values and a bufSize perimeter of zeros
+  const mWithBuf = init2dArray(mWithBufWidth, mWithBufHeight);
+
+  // Add the buffer
+  for (let x = 0; x < mWithBufWidth; x++) {
+    for (let y = 0; y < mWithBufHeight; y++) {
+      // top row buffer
+      if (y < bufSize) {
+        // top left buffer
+        if (x < bufSize) {
+          mWithBuf[x][y] = m[0][0];
+        // top mid buffer
+        } else if (x < bufSize + mWidth) {
+          mWithBuf[x][y] = m[x - bufSize][0];
+        // top right buffer
+        } else {
+          mWithBuf[x][y] = m[mWidth - 1][0];
+        }
+      } else if (y < bufSize + mWidth) {
+        // mid left buffer
+        if (x < bufSize) {
+          mWithBuf[x][y] = m[0][y - bufSize];
+        // original matrix (not buffer)
+        } else if (x < bufSize + mWidth) {
+          mWithBuf[x][y] = m[x - bufSize][y - bufSize];
+        } else {
+          mWithBuf[x][y] = m[mWidth - 1][y - bufSize];
+        }
+      } else if (y < mWithBufWidth) {
+        // bot left buffer
+        if (x < bufSize) {
+          mWithBuf[x][y] = m[0][mHeight - 1];
+        // bot mid buffer
+        } else if (x < bufSize + mWidth) {
+          mWithBuf[x][y] = m[x - bufSize][mHeight - 1];
+        // bot right buffer
+        } else {
+          mWithBuf[x][y] = m[mWidth - 1][mHeight - 1];
+        }
+      }
+    }
+  }
+
+  return mWithBuf;
+}
+

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -262,3 +262,31 @@ export function addBufferTo2dArray(m, bufSize, bufVal) {
   return mWithBuf;
 }
 
+
+/*
+ * Returns a specified section from a 2D array.
+ *
+ * array: the 2D array to get the subarray from
+ * xCenter: the x index of the center of the subarray
+ * yCenter: the y index of the center of the subarray
+ * width: the width of the subarray (must be an odd number)
+ * height: the height of the subarray (must be an odd number)
+ */
+export function getSubarrayFrom2dArray(array, xCenter, yCenter, width, height) {
+  const halfWidth = (width - 1) / 2;
+  const halfHeight = (height - 1) / 2;
+  const leftEdge = xCenter - halfWidth;
+  const rightEdge = xCenter + halfWidth;
+  const topEdge = yCenter - halfHeight;
+  const botEdge = yCenter + halfHeight;
+
+  const initVal = 0;
+  const subarray = init2dArray(width, height, initVal);
+  for (let x = leftEdge; x <= rightEdge; x++) {
+    for (let y = topEdge; y <= botEdge; y++) {
+      subarray[x - leftEdge][y - topEdge] = array[x][y];
+    }
+  }
+
+  return subarray;
+}

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -1,6 +1,7 @@
 import { tileTypes, PIXELS_PER_TILE } from '../constants';
 import { amBlue, amRed } from './player';
 
+
 /*
  * Returns true if tileID is traversable without consequences.
  *
@@ -60,6 +61,7 @@ export function isTraversable(tileID) {
       return false;
   }
 }
+
 
 /* eslint no-param-reassign: ["error", { "ignorePropertyModificationsFor": ["bigGrid"] }] */
 /*
@@ -157,6 +159,7 @@ export function getTraversableCells(cpt, map) {
   return emptyCells;
 }
 
+
 /*
  * Returns the position (in pixels x,y and grid positions xg, yg
  * of first of the specified tile types to appear starting in the
@@ -180,4 +183,29 @@ export function findTile(tiles) {
   }
   console.error(`Unable to find tile: ${tiles}`);
   return {};
+
+
+/*
+ * Returns the sum of all corresponding elements from two matrices being
+ * multiplied together. For example:
+ *   a = 1 2   b = 4 1
+ *       3 4       2 3
+ *   multiplyCorrespondingElementsAndSum(a, b)
+ *   (1*4) + (2*1) + (3*2) + (4*3) = 21
+ *
+ * m1: the first matrix
+ * m2: the second matrix (of the same dimensions as m1)
+ */
+export function multiplyCorrespondingElementsAndSum(m1, m2) {
+  const mWidth = m1.length;
+  const mHeight = m1[0].length;
+  let sum = 0;
+
+  for (let x = 0; x < mWidth; x++) {
+    for (let y = 0; y < mHeight; y++) {
+      sum += m1[x][y] * m2[x][y];
+    }
+  }
+
+  return sum;
 }

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -183,6 +183,29 @@ export function findTile(tiles) {
   }
   console.error(`Unable to find tile: ${tiles}`);
   return {};
+}
+
+
+/*
+ * Initializes and returns a 2D array with the specified width, height, and
+ * default value.
+ *
+ * width: the width of the initialized 2D array
+ * height: the height of the initialized 2D array
+ * defaultVal: the value to give each element in the initialized 2D array
+ */
+export function init2dArray(width, height, defaultVal = 0) {
+  const matrix = [];
+
+  for (let x = 0; x < width; x++) {
+    matrix[x] = new Array(height);
+    for (let y = 0; y < height; y++) {
+      matrix[x][y] = defaultVal;
+    }
+  }
+
+  return matrix;
+}
 
 
 /*

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -1,6 +1,6 @@
 import { tileTypes, PIXELS_PER_TILE } from '../constants';
 import { amBlue, amRed } from './player';
-import * as utils from '../../src/utils';
+import { assert } from '../../src/utils';
 
 
 /*
@@ -221,13 +221,14 @@ export function init2dArray(width, height, defaultVal) {
  * m2: the second matrix (of the same dimensions as m1)
  */
 export function multiplyCorrespondingElementsAndSum(m1, m2) {
-  let condition = (m1.length === m2.length);
-  let errorMessage = 'multiplyCorrespondingElementsAndSum: m1 and m2 are not the same width';
-  utils.assert(condition, errorMessage);
-
-  condition = (m1[0].length === m2[0].length);
-  errorMessage = 'multiplyCorrespondingElementsAndSum: m1 and m2 are not the same height';
-  utils.assert(condition, errorMessage);
+  assert(
+    m1.length === m2.length,
+    'multiplyCorrespondingElementsAndSum: m1 and m2 are not the same width',
+  );
+  assert(
+    m1[0].length === m2[0].length,
+    'multiplyCorrespondingElementsAndSum: m1 and m2 are not the same height',
+  );
 
   const mWidth = m1.length;
   const mHeight = m1[0].length;
@@ -282,13 +283,8 @@ export function addBufferTo2dArray(m, bufSize, bufVal) {
  * height: the height of the subarray (must be an odd number)
  */
 export function getSubarrayFrom2dArray(array, xCenter, yCenter, width, height) {
-  let condition = (width % 2 === 1);
-  let errorMessage = 'getSubarrayFrom2dArray: width is not odd';
-  utils.assert(condition, errorMessage);
-
-  condition = (height % 2 === 1);
-  errorMessage = 'getSubarrayFrom2dArray: height is not odd';
-  utils.assert(condition, errorMessage);
+  assert(width % 2 === 1, 'getSubarrayFrom2dArray: width is not odd');
+  assert(height % 2 === 1, 'getSubarrayFrom2dArray: height is not odd');
 
   const halfWidth = (width - 1) / 2;
   const halfHeight = (height - 1) / 2;
@@ -319,13 +315,8 @@ export function getSubarrayFrom2dArray(array, xCenter, yCenter, width, height) {
 export function convolve(m, k) {
   const kWidth = k.length;
   const kHeight = k[0].length;
-  let condition = (kWidth === kHeight);
-  let errorMessage = 'Kernel\'s width is not equal to kernel\'s height';
-  utils.assert(condition, errorMessage);
-
-  condition = (((kWidth - 1) % 2) === 0);
-  errorMessage = 'Kernel\'s width is not odd';
-  utils.assert(condition, errorMessage);
+  assert(kWidth === kHeight, 'convolve: kernel\'s width is not equal to kernel\'s height');
+  assert(kWidth % 2 === 1, 'convolve: kernel\'s width is not odd');
 
   const mWidth = m.length;
   const mHeight = m[0].length;

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -1,5 +1,6 @@
 import { tileTypes, PIXELS_PER_TILE } from '../constants';
 import { amBlue, amRed } from './player';
+import * as utils from '../../src/utils';
 
 
 /*
@@ -220,6 +221,14 @@ export function init2dArray(width, height, defaultVal) {
  * m2: the second matrix (of the same dimensions as m1)
  */
 export function multiplyCorrespondingElementsAndSum(m1, m2) {
+  let condition = (m1.length === m2.length);
+  let errorMessage = 'multiplyCorrespondingElementsAndSum: m1 and m2 are not the same width';
+  utils.assert(condition, errorMessage);
+
+  condition = (m1[0].length === m2[0].length);
+  errorMessage = 'multiplyCorrespondingElementsAndSum: m1 and m2 are not the same height';
+  utils.assert(condition, errorMessage);
+
   const mWidth = m1.length;
   const mHeight = m1[0].length;
   let sum = 0;
@@ -273,6 +282,14 @@ export function addBufferTo2dArray(m, bufSize, bufVal) {
  * height: the height of the subarray (must be an odd number)
  */
 export function getSubarrayFrom2dArray(array, xCenter, yCenter, width, height) {
+  let condition = (width % 2 === 1);
+  let errorMessage = 'getSubarrayFrom2dArray: width is not odd';
+  utils.assert(condition, errorMessage);
+
+  condition = (height % 2 === 1);
+  errorMessage = 'getSubarrayFrom2dArray: height is not odd';
+  utils.assert(condition, errorMessage);
+
   const halfWidth = (width - 1) / 2;
   const halfHeight = (height - 1) / 2;
   const leftEdge = xCenter - halfWidth;

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -307,3 +307,41 @@ export function getSubarrayFrom2dArray(array, xCenter, yCenter, width, height) {
 
   return subarray;
 }
+
+
+/*
+ * Returns a 2D array that is the result of the convolution of m and k.
+ *
+ * m: the first 2D array in the convolution
+ * k: the second 2D array in the convolution, also called the kernel (must
+ *   have sides of equal length and the sides must have an odd length)
+ */
+export function convolve(m, k) {
+  const kWidth = k.length;
+  const kHeight = k[0].length;
+  let condition = (kWidth === kHeight);
+  let errorMessage = 'Kernel\'s width is not equal to kernel\'s height';
+  utils.assert(condition, errorMessage);
+
+  condition = (((kWidth - 1) % 2) === 0);
+  errorMessage = 'Kernel\'s width is not odd';
+  utils.assert(condition, errorMessage);
+
+  const mWidth = m.length;
+  const mHeight = m[0].length;
+  const kSize = kWidth;
+  const bufSize = (kSize - 1) / 2;
+  const bufVal = 1;
+  const mWithBuf = addBufferTo2dArray(m, bufSize, bufVal);
+
+  let mSubarray = init2dArray(kSize, kSize, 0);
+  const convolution = init2dArray(mWidth, mHeight, 0);
+  for (let x = 0; x < mWidth; x++) {
+    for (let y = 0; y < mHeight; y++) {
+      mSubarray = getSubarrayFrom2dArray(mWithBuf, x + bufSize, y + bufSize, kWidth, kWidth);
+      convolution[x][y] = multiplyCorrespondingElementsAndSum(mSubarray, k);
+    }
+  }
+
+  return convolution;
+}

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -235,77 +235,29 @@ export function multiplyCorrespondingElementsAndSum(m1, m2) {
 
 
 /* Returns a matrix with a buffer applied around its perimeter. Example:
- *   Take the element values in the corners of the matrix and apply them
- *   as a bufSize by bufSize matrix to the new corners
- *   Example:
- *     m = 1 2 3   bufSize = 2   mWithBuf = 1 1       3 3
- *         4 5 6                            1 1       3 3
- *         7 8 9                                1 2 3
- *                                              4 5 6
- *                                              7 8 9
- *                                          7 7       9 9
- *                                          7 7       9 9
- *   Take the element values on the edges of the matrix and apply them as
- *   rows/columns that are bufSize long to the new edges
- *     mWithBuf = 1 1       3 3   bufSize = 2  mWithBuf = 1 1 1 2 3 3 3
- *                1 1       3 3                           1 1 1 2 3 3 3
- *                    1 2 3                               1 1 1 2 3 3 3
- *                    4 5 6                               4 4 4 5 6 6 6
- *                    7 8 9                               7 7 7 8 9 9 9
- *                7 7       9 9                           7 7 7 8 9 9 9
- *                7 7       9 9                           7 7 7 8 9 9 9
+ *   Take the element values of the matrix and apply a bufSize perimeter
+ *   of value bufVal.
+ *     mWithBuf = 1 2 3   bufSize = 2   mWithBuf = 1 1 1 1 1 1 1
+ *                4 5 6                            1 1 1 1 1 1 1
+ *                7 8 9   bufVal = 1               1 1 1 2 3 1 1
+ *                                                 1 1 4 5 6 1 1
+ *                                                 1 1 7 8 9 1 1
+ *                                                 1 1 1 1 1 1 1
+ *                                                 1 1 1 1 1 1 1
  *
  * m: a 2D array, which will have a buffer added around its perimeter
  * bufSize: the size of buffer to add around the matrix
+ * bufVal: the value to fill the buffer with
  */
-export function addBufferTo2dArray(m, bufSize) {
+export function addBufferTo2dArray(m, bufSize, bufVal) {
   const mWidth = m.length;
   const mHeight = m[0].length;
   const mWithBufWidth = mWidth + (bufSize * 2);
   const mWithBufHeight = mHeight + (bufSize * 2);
 
   // Create a grid with matrix's values and a bufSize perimeter of zeros
-  const mWithBuf = init2dArray(mWithBufWidth, mWithBufHeight, 0);
-
-  // Add the buffer
-  for (let x = 0; x < mWithBufWidth; x++) {
-    for (let y = 0; y < mWithBufHeight; y++) {
-      // top row buffer
-      if (y < bufSize) {
-        // top left buffer
-        if (x < bufSize) {
-          mWithBuf[x][y] = m[0][0];
-        // top mid buffer
-        } else if (x < bufSize + mWidth) {
-          mWithBuf[x][y] = m[x - bufSize][0];
-        // top right buffer
-        } else {
-          mWithBuf[x][y] = m[mWidth - 1][0];
-        }
-      } else if (y < bufSize + mWidth) {
-        // mid left buffer
-        if (x < bufSize) {
-          mWithBuf[x][y] = m[0][y - bufSize];
-        // original matrix (not buffer)
-        } else if (x < bufSize + mWidth) {
-          mWithBuf[x][y] = m[x - bufSize][y - bufSize];
-        } else {
-          mWithBuf[x][y] = m[mWidth - 1][y - bufSize];
-        }
-      } else if (y < mWithBufWidth) {
-        // bot left buffer
-        if (x < bufSize) {
-          mWithBuf[x][y] = m[0][mHeight - 1];
-        // bot mid buffer
-        } else if (x < bufSize + mWidth) {
-          mWithBuf[x][y] = m[x - bufSize][mHeight - 1];
-        // bot right buffer
-        } else {
-          mWithBuf[x][y] = m[mWidth - 1][mHeight - 1];
-        }
-      }
-    }
-  }
+  const mWithBuf = init2dArray(mWithBufWidth, mWithBufHeight, bufVal);
+  fillGridWithSubgrid(mWithBuf, m, bufSize, bufSize);
 
   return mWithBuf;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,3 +53,19 @@ export function setupVelocity() {
     return this.m_linearVelocity;
   };
 }
+
+/*
+ * Throws a specified error message if a condition is not met. If no message
+ * is specified, then a default error message is thrown.
+ *
+ * condition: the condition, which, if false, will cause an error to be thrown
+ * message: the error message to throw if condition is not true
+ */
+export function assert(condition, message = "Assertion failed") {
+  if (!condition) {
+    if (typeof Error !== "undefined") {
+      throw new Error(message);
+    }
+    throw message;
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -59,13 +59,13 @@ export function setupVelocity() {
  * is specified, then a default error message is thrown.
  *
  * condition: the condition, which, if false, will cause an error to be thrown
- * message: the error message to throw if condition is not true
+ * errorMessage: the error message to throw if condition is not true
  */
-export function assert(condition, message = "Assertion failed") {
+export function assert(condition, errorMessage = 'Assertion failed') {
   if (!condition) {
-    if (typeof Error !== "undefined") {
-      throw new Error(message);
+    if (typeof Error !== 'undefined') {
+      throw new Error(errorMessage);
     }
-    throw message;
+    throw errorMessage;
   }
 }

--- a/tests/map.spec.js
+++ b/tests/map.spec.js
@@ -63,7 +63,7 @@ test('test addBufferTo2dArray', t => {
     [7, 7, 7, 8, 9, 9, 9],
     [7, 7, 7, 8, 9, 9, 9],
   ];
-  t.same(helpers.addBufferTo2dArray(matrix, bufferSize), expected);
+  t.same(map.addBufferTo2dArray(matrix, bufferSize), expected);
 });
 
 test('test traversableCellsInTile', t => {
@@ -204,7 +204,7 @@ test('test init2dArray', t => {
     [1, 1, 1],
     [1, 1, 1],
   ];
-  t.same(helpers.init2dArray(width, height, defaultVal), expected);
+  t.same(map.init2dArray(width, height, defaultVal), expected);
 
   width = 3;
   height = 3;
@@ -214,7 +214,7 @@ test('test init2dArray', t => {
     [55, 55, 55],
     [55, 55, 55],
   ];
-  t.same(helpers.init2dArray(width, height, defaultVal), expected);
+  t.same(map.init2dArray(width, height, defaultVal), expected);
 });
 
 
@@ -235,5 +235,5 @@ test('test multiplyCorrespondingElementsAndSum', t => {
 
   const expected = 165;
 
-  t.same(helpers.multiplyCorrespondingElementsAndSum(m1, m2), expected);
+  t.is(map.multiplyCorrespondingElementsAndSum(m1, m2), expected);
 });

--- a/tests/map.spec.js
+++ b/tests/map.spec.js
@@ -279,3 +279,62 @@ test('test multiplyCorrespondingElementsAndSum', t => {
 
   t.is(map.multiplyCorrespondingElementsAndSum(m1, m2), expected);
 });
+
+test('test convolve', t => {
+  t.plan(3);
+
+  let m = [
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+  ];
+  let k = [
+    [1],
+  ];
+  let expected = [
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+  ];
+  t.same(map.convolve(m, k), expected);
+
+  m = [
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+  ];
+  k = [
+    [2],
+  ];
+  /* eslint-disable array-bracket-spacing*/
+  /* eslint-disable no-multi-spaces*/
+  expected = [
+    [ 2,  4,  6],
+    [ 8, 10, 12],
+    [14, 16, 18],
+  ];
+  /* eslint-enable array-bracket-spacing*/
+  /* eslint-enable no-multi-spaces*/
+  t.same(map.convolve(m, k), expected);
+
+  m = [
+    [1, 2, 3, 4],
+    [5, 6, 7, 8],
+    [9, 0, 1, 2],
+  ];
+  k = [
+    [1, 2, 3],
+    [3, 4, 5],
+    [6, 7, 8],
+  ];
+  /* eslint-disable array-bracket-spacing*/
+  /* eslint-disable no-multi-spaces*/
+  expected = [
+    [112, 160, 193, 142],
+    [131, 150, 129, 100],
+    [ 89,  91,  79,  63],
+  ];
+  /* eslint-enable array-bracket-spacing*/
+  /* eslint-enable no-multi-spaces*/
+  t.same(map.convolve(m, k), expected);
+});

--- a/tests/map.spec.js
+++ b/tests/map.spec.js
@@ -172,15 +172,13 @@ test('test getTraversableCells', t => {
   // define the number of cells per tile
   let cpt = 1;
 
-  /* eslint-disable no-multi-spaces */
-  /* eslint-disable array-bracket-spacing */
+  /* eslint-disable no-multi-spaces, array-bracket-spacing */
   const mockMap = [
     [bomb,    blank,    redgate],
     [redgate, bluegate, blank  ],
     [blank,   spike,    bomb   ],
   ];
-  /* eslint-enable no-multi-spaces */
-  /* eslint-enable array-bracket-spacing */
+  /* eslint-enable no-multi-spaces, array-bracket-spacing */
 
   // this is what we expect the function to return
   let expected = [
@@ -306,15 +304,13 @@ test('test convolve', t => {
   k = [
     [2],
   ];
-  /* eslint-disable array-bracket-spacing*/
-  /* eslint-disable no-multi-spaces*/
+  /* eslint-disable no-multi-spaces, array-bracket-spacing*/
   expected = [
     [ 2,  4,  6],
     [ 8, 10, 12],
     [14, 16, 18],
   ];
-  /* eslint-enable array-bracket-spacing*/
-  /* eslint-enable no-multi-spaces*/
+  /* eslint-enable no-multi-spaces, array-bracket-spacing */
   t.same(map.convolve(m, k), expected);
 
   m = [
@@ -327,14 +323,12 @@ test('test convolve', t => {
     [3, 4, 5],
     [6, 7, 8],
   ];
-  /* eslint-disable array-bracket-spacing*/
-  /* eslint-disable no-multi-spaces*/
+  /* eslint-disable no-multi-spaces, array-bracket-spacing*/
   expected = [
     [112, 160, 193, 142],
     [131, 150, 129, 100],
     [ 89,  91,  79,  63],
   ];
-  /* eslint-enable array-bracket-spacing*/
-  /* eslint-enable no-multi-spaces*/
+  /* eslint-enable no-multi-spaces, array-bracket-spacing */
   t.same(map.convolve(m, k), expected);
 });

--- a/tests/map.spec.js
+++ b/tests/map.spec.js
@@ -167,3 +167,23 @@ test('test getTraversableCells', t => {
 
   t.same(map.getTraversableCells(cpt, smallMap), expected);
 });
+
+test('test multiplyCorrespondingElementsAndSum', t => {
+  t.plan(1);
+
+  const m1 = [
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+  ];
+
+  const m2 = [
+    [9, 8, 7],
+    [6, 5, 4],
+    [3, 2, 1],
+  ];
+
+  const expected = 165;
+
+  t.same(helpers.multiplyCorrespondingElementsAndSum(m1, m2), expected);
+});

--- a/tests/map.spec.js
+++ b/tests/map.spec.js
@@ -3,6 +3,7 @@ import * as map from '../src/helpers/map';
 import { tileTypes, teams } from '../src/constants';
 import { mockMe } from '../src/helpers/player';
 
+
 test('test fillGridWithSubgrid', t => {
   t.plan(2);
   let grid = [
@@ -168,6 +169,7 @@ test('test getTraversableCells', t => {
   t.same(map.getTraversableCells(cpt, smallMap), expected);
 });
 
+
 test('test init2dArray', t => {
   t.plan(2);
 
@@ -193,6 +195,7 @@ test('test init2dArray', t => {
   ];
   t.same(helpers.init2dArray(width, height, defaultVal), expected);
 });
+
 
 test('test multiplyCorrespondingElementsAndSum', t => {
   t.plan(1);

--- a/tests/map.spec.js
+++ b/tests/map.spec.js
@@ -53,17 +53,18 @@ test('test addBufferTo2dArray', t => {
     [4, 5, 6],
     [7, 8, 9],
   ];
-  const bufferSize = 2;
+  const bufSize = 2;
+  const bufVal = 1;
   const expected = [
-    [1, 1, 1, 2, 3, 3, 3],
-    [1, 1, 1, 2, 3, 3, 3],
-    [1, 1, 1, 2, 3, 3, 3],
-    [4, 4, 4, 5, 6, 6, 6],
-    [7, 7, 7, 8, 9, 9, 9],
-    [7, 7, 7, 8, 9, 9, 9],
-    [7, 7, 7, 8, 9, 9, 9],
+    [1, 1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 2, 3, 1, 1],
+    [1, 1, 4, 5, 6, 1, 1],
+    [1, 1, 7, 8, 9, 1, 1],
+    [1, 1, 1, 1, 1, 1, 1],
+    [1, 1, 1, 1, 1, 1, 1],
   ];
-  t.same(map.addBufferTo2dArray(matrix, bufferSize), expected);
+  t.same(map.addBufferTo2dArray(matrix, bufSize, bufVal), expected);
 });
 
 test('test traversableCellsInTile', t => {

--- a/tests/map.spec.js
+++ b/tests/map.spec.js
@@ -45,6 +45,27 @@ test('test fillGridWithSubgrid', t => {
   t.same(grid, expected);
 });
 
+test('test addBufferTo2dArray', t => {
+  t.plan(1);
+
+  const matrix = [
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+  ];
+  const bufferSize = 2;
+  const expected = [
+    [1, 1, 1, 2, 3, 3, 3],
+    [1, 1, 1, 2, 3, 3, 3],
+    [1, 1, 1, 2, 3, 3, 3],
+    [4, 4, 4, 5, 6, 6, 6],
+    [7, 7, 7, 8, 9, 9, 9],
+    [7, 7, 7, 8, 9, 9, 9],
+    [7, 7, 7, 8, 9, 9, 9],
+  ];
+  t.same(helpers.addBufferTo2dArray(matrix, bufferSize), expected);
+});
+
 test('test traversableCellsInTile', t => {
   t.plan(5);
   let expected = [

--- a/tests/map.spec.js
+++ b/tests/map.spec.js
@@ -67,6 +67,47 @@ test('test addBufferTo2dArray', t => {
   t.same(map.addBufferTo2dArray(matrix, bufSize, bufVal), expected);
 });
 
+test('test getSubarrayFrom2dArray', t => {
+  t.plan(2);
+
+  let array = [
+    [1, 2, 3, 4],
+    [5, 6, 7, 8],
+    [9, 0, 1, 2],
+    [3, 4, 5, 6],
+  ];
+  let xCenter = 2;
+  let yCenter = 2;
+  let width = 3;
+  let height = 3;
+  let expected = [
+    [6, 7, 8],
+    [0, 1, 2],
+    [4, 5, 6],
+  ];
+  t.same(map.getSubarrayFrom2dArray(array, xCenter, yCenter, width, height), expected);
+
+  array = [
+    [1, 2, 3, 4, 5, 6],
+    [7, 8, 9, 0, 1, 2],
+    [3, 4, 5, 6, 7, 8],
+    [9, 0, 1, 2, 3, 4],
+    [5, 6, 7, 8, 9, 0],
+  ];
+  xCenter = 2;
+  yCenter = 1;
+  width = 5;
+  height = 3;
+  expected = [
+    [1, 2, 3],
+    [7, 8, 9],
+    [3, 4, 5],
+    [9, 0, 1],
+    [5, 6, 7],
+  ];
+  t.same(map.getSubarrayFrom2dArray(array, xCenter, yCenter, width, height), expected);
+});
+
 test('test traversableCellsInTile', t => {
   t.plan(5);
   let expected = [

--- a/tests/map.spec.js
+++ b/tests/map.spec.js
@@ -168,6 +168,32 @@ test('test getTraversableCells', t => {
   t.same(map.getTraversableCells(cpt, smallMap), expected);
 });
 
+test('test init2dArray', t => {
+  t.plan(2);
+
+  let width = 5;
+  let height = 3;
+  let defaultVal = 1;
+  let expected = [
+    [1, 1, 1],
+    [1, 1, 1],
+    [1, 1, 1],
+    [1, 1, 1],
+    [1, 1, 1],
+  ];
+  t.same(helpers.init2dArray(width, height, defaultVal), expected);
+
+  width = 3;
+  height = 3;
+  defaultVal = 55;
+  expected = [
+    [55, 55, 55],
+    [55, 55, 55],
+    [55, 55, 55],
+  ];
+  t.same(helpers.init2dArray(width, height, defaultVal), expected);
+});
+
 test('test multiplyCorrespondingElementsAndSum', t => {
   t.plan(1);
 

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -1,0 +1,13 @@
+import test from 'tape';
+import * as utils from '../src/utils';
+
+
+test('test assert', t => {
+  t.plan(2);
+
+  let condition = false;
+  t.throws(() => { utils.assert(condition); });
+
+  condition = true;
+  t.doesNotThrow(() => { utils.assert(condition); });
+});


### PR DESCRIPTION
Closes #37 

The overall goal of this PR is to implement matrix manipulation functionality that allows us to add buffers around non-traversable objects in our isTraversable path-planning grid. Our TagproBot navigates based on its center (not its edges), and because our TagproBot has a radius of 19 pixels, we will need to add a ~19 pixel buffer around any obstacles that we should avoid during path planning. [This can be done by using convolution.](http://setosa.io/ev/image-kernels/)

### New functions:
- **`/src/helpers/map.js`**
  - `init2dArray`
  - `multiplyCorrespondingElementsAndSum`
  - `addBufferTo2dArray`
  - `getSubarrayFrom2dArray`
  - `convolve`
- **`/src/utils.js`**
  - `assert`