### PR TITLE
48: run webpack once

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | b
 
 
 ## Running the App
-- Run `npm run build`.  This will start webpack, which will "watch" the files in `src/` and will update the bundle automatically.  This will also run eslint whenever your code changes so you can see if the linter fails. It will also automatically run unit tests whenever you save a file it is watching.
-- To test your code, make sure webpack is running and copy-paste the code in `public/bundle.js` into tampermonkey.
+- Run `npm run build`.  This will start webpack, which will "watch" the files in `src/` and will update the bundle automatically.  This will also run eslint whenever your code changes so you can see if the linter fails.
+- `npm run build:test` behaves similarly to `npm run build`, except it will also automatically run unit tests whenever you save a file it is watching, or save a test file
+- You can append `:once` to either of the previous commands to run webpack without watching the files for changes. `npm run build:once` and `npm run build:test:once`.
+- To test your code in tagpro, make sure webpack is running and copy-paste the code in `public/bundle.js` into tampermonkey.
 
 ## Terminology
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "lint": "eslint src/**/*.js tests/**/*.js",
     "lint:fix": "eslint src/**/*.js tests/**/*.js --fix",
     "test": "babel-tape-runner tests/**/*.js",
-    "build": "webpack --watch --env.test=false",
-    "build:test": "webpack --watch --env.test=true"
+    "build": "webpack --watch",
+    "build:once": "webpack",
+    "build:test": "webpack --watch --env.test=true",
+    "build:test:once": "webpack --env.test=true"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ var TEST_DIR = path.resolve(__dirname, 'tests/');
 
 module.exports = function(env) {
   exports = [];
-  if (env.test == 'true') {
+  if (env && env.test == 'true') {
     exports.push({
       entry: glob.sync(TEST_DIR + "/**/*.js"),
       target: 'node',


### PR DESCRIPTION
closes #48.

I made a small update to webpack.config.js which allows the user to run webpack without explicitly passing in env.test. The default behavior is to not run the tests, which is consistent with npm run build not running the tests.

I also added `:once` functionality to both `npm run build` and `npm run build:test`. I am starting to see that if we want more configuration on `npm run build` than this, doing it by explicitly changing the script names could start to get onerous. We should figure out a way to do it with command line flags, but so far, I haven't figured out how to do it.

I opened an issue #57 so we have a better long term solution later. For now I think this is alright.