### PR TITLE
61: easily autolint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | b
 3. In this directory, install the node packages, including webpack: `npm install`
 
 ## Testing the App
-- Run `npm test`. This will lint your test files, and then run them.
+- Run `npm test`. This will run all the test files
+
+## Auto-linting your code
+- Run `npm run lint`. This lint your code and perform any fixes that can be done automatically. It will then give a report of what you still need to fix.
+
 
 ## Running the App
 - Run `npm run build`.  This will start webpack, which will "watch" the files in `src/` and will update the bundle automatically.  This will also run eslint whenever your code changes so you can see if the linter fails. It will also automatically run unit tests whenever you save a file it is watching.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | b
 - Run `npm test`. This will run all the test files
 
 ## Auto-linting your code
-- Run `npm run lint`. This lint your code and perform any fixes that can be done automatically. It will then give a report of what you still need to fix.
+- Run `npm run lint:fix`. This lint your code and perform any fixes that can be done automatically. It will then give a report of what you still need to fix.
 
 
 ## Running the App

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "http-server",
     "lint": "eslint ./src/**/*.js ./tests/**/*.js --fix",
-    "test": "babel-tape-runner tests/*.js",
+    "test": "babel-tape-runner tests/**/*.js",
     "build": "webpack --watch --env.test=false",
     "build:test": "webpack --watch --env.test=true"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "scripts": {
     "start": "http-server",
-    "lint": "eslint ./src/**/*.js ./tests/**/*.js --fix",
+    "lint": "eslint src/**/*.js tests/**/*.js --fix",
     "test": "babel-tape-runner tests/**/*.js",
     "build": "webpack --watch --env.test=false",
     "build:test": "webpack --watch --env.test=true"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "scripts": {
     "start": "http-server",
-    "test": "eslint tests/*.js && node_modules/.bin/babel-tape-runner tests/*.js",
+    "lint": "eslint ./src/**/*.js ./tests/**/*.js --fix",
+    "test": "babel-tape-runner tests/*.js",
     "build": "webpack --watch --env.test=false",
     "build:test": "webpack --watch --env.test=true"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "scripts": {
     "start": "http-server",
-    "lint": "eslint src/**/*.js tests/**/*.js --fix",
+    "lint": "eslint src/**/*.js tests/**/*.js",
+    "lint:fix": "eslint src/**/*.js tests/**/*.js --fix",
     "test": "babel-tape-runner tests/**/*.js",
     "build": "webpack --watch --env.test=false",
     "build:test": "webpack --watch --env.test=true"


### PR DESCRIPTION
Closes #61 

Small update:

- I added `npm run lint:fix` as a standalone lint script, which will use the `--fix` flag to auto fix any easy errors you made.
- Because the `npm run lint` exists, I made `npm test` stop linting your files.