### PR TITLE
75: Visualize non-traversable cells, and toggle visuals

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -11,7 +11,7 @@ import { myTeamHasFlag, enemyTeamHasFlag } from './helpers/gameState';
 import { getMe } from './helpers/player';
 import { getShortestPath, getTarget } from './helpers/path';
 import { move } from './utils/interface';
-import { drawPlannedPath } from './draw/drawings';
+import { drawPlannedPath, drawNonTraversableCells } from './draw/drawings';
 
 /*
  * The logic/flowchart to get where our goal is.
@@ -75,12 +75,14 @@ function getSeek() {
     y: Math.floor(goal.y / PIXELS_PER_TILE),
   };
   const cellsPerTile = 1;
+  const traversableCells = getTraversableCells(cellsPerTile, tagpro.map);
+  drawNonTraversableCells(traversableCells, cellsPerTile);
   const shortestPath = getShortestPath(
     gridPosition.x,
     gridPosition.y,
     gridTarget.x,
     gridTarget.y,
-    getTraversableCells(cellsPerTile, tagpro.map),
+    traversableCells,
   );
   const seekToward = getTarget(
     gridPosition.x,

--- a/src/bot.js
+++ b/src/bot.js
@@ -12,6 +12,7 @@ import { getMe } from './helpers/player';
 import { getShortestPath, getTarget } from './helpers/path';
 import { move } from './utils/interface';
 import { drawPlannedPath, drawNonTraversableCells } from './draw/drawings';
+import { visualMode } from './index';
 
 /*
  * The logic/flowchart to get where our goal is.
@@ -76,7 +77,7 @@ function getSeek() {
   };
   const cellsPerTile = 1;
   const traversableCells = getTraversableCells(cellsPerTile, tagpro.map);
-  drawNonTraversableCells(traversableCells, cellsPerTile);
+  drawNonTraversableCells(traversableCells, cellsPerTile, visualMode());
   const shortestPath = getShortestPath(
     gridPosition.x,
     gridPosition.y,
@@ -93,7 +94,11 @@ function getSeek() {
   seekToward.y *= PIXELS_PER_TILE;
 
   // Visualize the planned path
+<<<<<<< HEAD
   drawPlannedPath(shortestPath, cellsPerTile);
+=======
+  drawPlannedPath(shortestPath, cellsPerTile, visualMode());
+>>>>>>> 3f03137... adding toggle visualization feature
 
   // Version for not attempting path-planning
   return {

--- a/src/bot.js
+++ b/src/bot.js
@@ -11,7 +11,7 @@ import { myTeamHasFlag, enemyTeamHasFlag } from './helpers/gameState';
 import { getMe } from './helpers/player';
 import { getShortestPath, getTarget } from './helpers/path';
 import { move } from './utils/interface';
-import drawPlannedPath from './draw/visualizePath';
+import { drawPlannedPath } from './draw/drawings';
 
 /*
  * The logic/flowchart to get where our goal is.

--- a/src/bot.js
+++ b/src/bot.js
@@ -93,11 +93,7 @@ function getSeek() {
   seekToward.y *= PIXELS_PER_TILE;
 
   // Visualize the planned path
-<<<<<<< HEAD
-  drawPlannedPath(shortestPath, cellsPerTile);
-=======
   drawPlannedPath(shortestPath, cellsPerTile, visualMode());
->>>>>>> 3f03137... adding toggle visualization feature
 
   // Version for not attempting path-planning
   return {

--- a/src/bot.js
+++ b/src/bot.js
@@ -10,9 +10,8 @@ import {
 import { myTeamHasFlag, enemyTeamHasFlag } from './helpers/gameState';
 import { getMe } from './helpers/player';
 import { getShortestPath, getTarget } from './helpers/path';
-import { move } from './utils/interface';
+import { move, visualMode } from './utils/interface';
 import { drawPlannedPath, drawNonTraversableCells } from './draw/drawings';
-import { visualMode } from './index';
 
 /*
  * The logic/flowchart to get where our goal is.

--- a/src/bot.js
+++ b/src/bot.js
@@ -10,7 +10,7 @@ import {
 import { myTeamHasFlag, enemyTeamHasFlag } from './helpers/gameState';
 import { getMe } from './helpers/player';
 import { getShortestPath, getTarget } from './helpers/path';
-import { move, visualMode } from './utils/interface';
+import { move } from './utils/interface';
 import { drawPlannedPath, drawNonTraversableCells } from './draw/drawings';
 
 /*
@@ -76,7 +76,7 @@ function getSeek() {
   };
   const cellsPerTile = 1;
   const traversableCells = getTraversableCells(cellsPerTile, tagpro.map);
-  drawNonTraversableCells(traversableCells, cellsPerTile, visualMode());
+  drawNonTraversableCells(traversableCells, cellsPerTile);
   const shortestPath = getShortestPath(
     gridPosition.x,
     gridPosition.y,
@@ -93,7 +93,7 @@ function getSeek() {
   seekToward.y *= PIXELS_PER_TILE;
 
   // Visualize the planned path
-  drawPlannedPath(shortestPath, cellsPerTile, visualMode());
+  drawPlannedPath(shortestPath, cellsPerTile);
 
   // Version for not attempting path-planning
   return {

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -8,10 +8,9 @@
  * seemed to be the best thing for this feature.
  *
  * There are two functions in the background object we will use: `addChild` and `removeChild`, each
- * of which take a reference to the object being drawn/removed. We use the tagpro global object to
- * store the objects currently draw on the screen in an array: `tagpro.rendered.pathSprites` (this
- * was from line 21 of the referenced userscript). Then, before drawing the path, we erase any path
- * that was previously drawn.
+ * of which take a reference to the object being drawn/removed. We use the variables pathSprites and
+ * nonTraversableCellSprites to store the sprites we're going to draw. Then, before drawing the
+ * path, we erase any path that was previously drawn.
  */
 import { PIXELS_PER_TILE } from '../constants';
 import { visualsOn } from '../utils/interface';
@@ -22,7 +21,7 @@ let nonTraversableCellSprites = [];
 
 /*
  * Takes in an array of cells, and creates an array of PIXI.Graphics objects (which the tagpro API
- * knows how to draw) and stores them in the global tagpro.renderer.pathSprites object.
+ * knows how to draw) and stores them in the pathSprites object.
  *
  * See: http://pixijs.download/dev/docs/PIXI.Graphics.html
  *
@@ -47,6 +46,15 @@ export function createPathSprites(path, cpt, hexColor, alpha) {
   });
 }
 
+/*
+ * Takes in an grid of cells, and creates an array of PIXI.Graphics objects for each non-traversable
+ * object and stores them in the nonTraversableCellSprites object.
+ *
+ * @param traversableCells: an grid of cells
+ * @param cpt: cells per tile, as defined throughout project
+ * @param notTraversableColor: the color the sprites should be
+ * @param alpha: the opacity: 0-1. 1 = opaque.
+ */
 function createNonTraversableCellSprites(
   traversableCells, cpt, notTraversableColor, alpha) {
   nonTraversableCellSprites = [];

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -17,6 +17,9 @@ import { PIXELS_PER_TILE } from '../constants';
 import { visualsOn } from '../utils/interface';
 import { clearSprites, drawSprites } from './utils';
 
+let pathSprites = [];
+let nonTraversableCellSprites = [];
+
 /*
  * Takes in an array of cells, and creates an array of PIXI.Graphics objects (which the tagpro API
  * knows how to draw) and stores them in the global tagpro.renderer.pathSprites object.
@@ -29,7 +32,7 @@ import { clearSprites, drawSprites } from './utils';
  * @param alpha: the opacity of the path drawing, 0-1. 1 = opaque.
  */
 export function createPathSprites(path, cpt, hexColor, alpha) {
-  tagpro.renderer.pathSprites = []; // initialize global object used for storage of PIXI.Graphics
+  pathSprites = []; // initialize global object used for storage of PIXI.Graphics
   const pixelsPerCell = PIXELS_PER_TILE / cpt; // dimensional analysis
   path.forEach(cell => { // create a PIXI.Graphics object for each cell in the path
     // note: all units in pixels
@@ -40,13 +43,13 @@ export function createPathSprites(path, cpt, hexColor, alpha) {
       pixelsPerCell, // width
       pixelsPerCell, // height
     ).alpha = alpha;
-    tagpro.renderer.pathSprites.push(rect);
+    pathSprites.push(rect);
   });
 }
 
 function createNonTraversableCellSprites(
   traversableCells, cpt, notTraversableColor, alpha) {
-  tagpro.renderer.nonTraversableCellSprites = [];
+  nonTraversableCellSprites = [];
   const pixelsPerCell = PIXELS_PER_TILE / cpt;
   for (let x = 0; x < traversableCells.length; x++) {
     for (let y = 0; y < traversableCells[0].length; y++) {
@@ -59,7 +62,7 @@ function createNonTraversableCellSprites(
           pixelsPerCell, // width
           pixelsPerCell, // height
         ).alpha = alpha;
-        tagpro.renderer.nonTraversableCellSprites.push(rect);
+        nonTraversableCellSprites.push(rect);
       }
     }
   }
@@ -71,18 +74,18 @@ function createNonTraversableCellSprites(
  * the corresponding cells in green on the map.
  */
 export function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
-  clearSprites(tagpro.renderer.pathSprites); // clear the previous path from the map
+  pathSprites = clearSprites(pathSprites); // clear the previous path from the map
   if (visualsOn()) {
     createPathSprites(path, cpt, hexColor, alpha); // create the PIXI.Graphics objecs we're drawing
   }
-  drawSprites(tagpro.renderer.pathSprites); // put the PIXI.Graphics objects on the map
+  drawSprites(pathSprites); // put the PIXI.Graphics objects on the map
 }
 
 export function drawNonTraversableCells(traversableCells, cpt, notTraversableColor = 0xff8c00,
   alpha = 0.4) {
-  clearSprites(tagpro.renderer.nonTraversableCellSprites);
+  nonTraversableCellSprites = clearSprites(nonTraversableCellSprites);
   if (visualsOn()) {
     createNonTraversableCellSprites(traversableCells, cpt, notTraversableColor, alpha);
   }
-  drawSprites(tagpro.renderer.nonTraversableCellSprites);
+  drawSprites(nonTraversableCellSprites);
 }

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -21,7 +21,7 @@ let nonTraversableCellSprites = [];
 
 /*
  * Takes in an array of cells, and creates an array of PIXI.Graphics objects (which the tagpro API
- * knows how to draw) and stores them in the pathSprites object.
+ * knows how to draw) and returns them
  *
  * See: http://pixijs.download/dev/docs/PIXI.Graphics.html
  *
@@ -31,7 +31,7 @@ let nonTraversableCellSprites = [];
  * @param alpha: the opacity of the path drawing, 0-1. 1 = opaque.
  */
 export function createPathSprites(path, cpt, hexColor, alpha) {
-  pathSprites = []; // initialize global object used for storage of PIXI.Graphics
+  const sprites = []; // initialize global object used for storage of PIXI.Graphics
   const pixelsPerCell = PIXELS_PER_TILE / cpt; // dimensional analysis
   path.forEach(cell => { // create a PIXI.Graphics object for each cell in the path
     // note: all units in pixels
@@ -42,13 +42,14 @@ export function createPathSprites(path, cpt, hexColor, alpha) {
       pixelsPerCell, // width
       pixelsPerCell, // height
     ).alpha = alpha;
-    pathSprites.push(rect);
+    sprites.push(rect);
   });
+  return sprites;
 }
 
 /*
  * Takes in an grid of cells, and creates an array of PIXI.Graphics objects for each non-traversable
- * object and stores them in the nonTraversableCellSprites object.
+ * object and returns them.
  *
  * @param traversableCells: an grid of cells
  * @param cpt: cells per tile, as defined throughout project
@@ -57,7 +58,7 @@ export function createPathSprites(path, cpt, hexColor, alpha) {
  */
 function createNonTraversableCellSprites(
   traversableCells, cpt, notTraversableColor, alpha) {
-  nonTraversableCellSprites = [];
+  const sprites = [];
   const pixelsPerCell = PIXELS_PER_TILE / cpt;
   for (let x = 0; x < traversableCells.length; x++) {
     for (let y = 0; y < traversableCells[0].length; y++) {
@@ -70,10 +71,11 @@ function createNonTraversableCellSprites(
           pixelsPerCell, // width
           pixelsPerCell, // height
         ).alpha = alpha;
-        nonTraversableCellSprites.push(rect);
+        sprites.push(rect);
       }
     }
   }
+  return sprites;
 }
 
 /*
@@ -84,7 +86,8 @@ function createNonTraversableCellSprites(
 export function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
   pathSprites = clearSprites(pathSprites); // clear the previous path from the map
   if (areVisualsOn()) {
-    createPathSprites(path, cpt, hexColor, alpha); // create the PIXI.Graphics objecs we're drawing
+    // create the PIXI.Graphics objecs we're drawing
+    pathSprites = createPathSprites(path, cpt, hexColor, alpha);
   }
   drawSprites(pathSprites); // put the PIXI.Graphics objects on the map
 }
@@ -93,7 +96,8 @@ export function drawNonTraversableCells(traversableCells, cpt, notTraversableCol
   alpha = 0.4) {
   nonTraversableCellSprites = clearSprites(nonTraversableCellSprites);
   if (areVisualsOn()) {
-    createNonTraversableCellSprites(traversableCells, cpt, notTraversableColor, alpha);
+    nonTraversableCellSprites = createNonTraversableCellSprites(traversableCells, cpt,
+      notTraversableColor, alpha);
   }
   drawSprites(nonTraversableCellSprites);
 }

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -14,6 +14,7 @@
  * that was previously drawn.
  */
 import { PIXELS_PER_TILE } from '../constants';
+import { clearSprites, drawSprites } from './utils';
 
 /*
  * Takes in an array of cells, and creates an array of PIXI.Graphics objects (which the tagpro API
@@ -43,34 +44,13 @@ export function createPathSprites(path, cpt, hexColor, alpha) {
 }
 
 /*
- * If tagpro.renderer.pathSprites has been initialized, iterate through each stored object and
- * remove it from the background. Used for removing the drawing of the previous path from the map.
- */
-export function clearRects() {
-  if (tagpro.renderer.pathSprites) {
-    tagpro.renderer.pathSprites.forEach(sprite => {
-      tagpro.renderer.layers.background.removeChild(sprite);
-    });
-  }
-}
-
-/*
- * Iterates over each PIXI.Graphics object in tagpro.renderer.pathSprites and adds it to the
- * background
- */
-export function drawRects() {
-  tagpro.renderer.pathSprites.forEach(sprite => {
-    tagpro.renderer.layers.background.addChild(sprite);
-  });
-}
-
-/*
  * Used to draw the bot's planned path. Takes in a reference to a list of cells returned by
  * getShortestPath() in helpers/path.js and the cpt used when calculating shortest path, and draws
  * the corresponding cells in green on the map.
  */
-export default function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
-  clearRects(); // clear the previous path from the map
+export function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
+  clearSprites(tagpro.renderer.pathSprites); // clear the previous path from the map
   createPathSprites(path, cpt, hexColor, alpha); // create the PIXI.Graphics objecs we're drawing
-  drawRects(); // put the PIXI.Graphics objects on the map
+  drawSprites(tagpro.renderer.pathSprites); // put the PIXI.Graphics objects on the map
 }
+

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -44,14 +44,15 @@ export function createPathSprites(path, cpt, hexColor, alpha) {
 }
 
 function createNonTraversableCellSprites(
-  traversableCells, cpt, notTraverableColor, alpha) {
+  traversableCells, cpt, notTraversableColor, alpha) {
   tagpro.renderer.nonTraversableCellSprites = [];
   const pixelsPerCell = PIXELS_PER_TILE / cpt;
   for (let x = 0; x < traversableCells.length; x++) {
     for (let y = 0; y < traversableCells[0].length; y++) {
-      if (!traversableCells[x][y]) { // if cell is non traversable
+      // if cell is non traversable and not an empty space
+      if (!traversableCells[x][y]) {
         const rect = new PIXI.Graphics();
-        rect.beginFill(notTraverableColor).drawRect(
+        rect.beginFill(notTraversableColor).drawRect(
           x * pixelsPerCell, // x coordinate
           y * pixelsPerCell, // y coordinate
           pixelsPerCell, // width
@@ -77,10 +78,10 @@ export function drawPlannedPath(path, cpt, visuals = true, hexColor = 0x00ff00, 
 }
 
 export function drawNonTraversableCells(traversableCells, cpt, visuals = true,
-  notTraverableColor = 0xff8c00, alpha = 0.4) {
+  notTraversableColor = 0xff8c00, alpha = 0.4) {
   clearSprites(tagpro.renderer.nonTraversableCellSprites);
   if (visuals) {
-    createNonTraversableCellSprites(traversableCells, cpt, notTraverableColor, alpha);
+    createNonTraversableCellSprites(traversableCells, cpt, notTraversableColor, alpha);
   }
   drawSprites(tagpro.renderer.nonTraversableCellSprites);
 }

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -68,15 +68,19 @@ function createNonTraversableCellSprites(
  * getShortestPath() in helpers/path.js and the cpt used when calculating shortest path, and draws
  * the corresponding cells in green on the map.
  */
-export function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
+export function drawPlannedPath(path, cpt, visuals = true, hexColor = 0x00ff00, alpha = 0.25) {
   clearSprites(tagpro.renderer.pathSprites); // clear the previous path from the map
-  createPathSprites(path, cpt, hexColor, alpha); // create the PIXI.Graphics objecs we're drawing
+  if (visuals) {
+    createPathSprites(path, cpt, hexColor, alpha); // create the PIXI.Graphics objecs we're drawing
+  }
   drawSprites(tagpro.renderer.pathSprites); // put the PIXI.Graphics objects on the map
 }
 
-export function drawNonTraversableCells(traversableCells, cpt,
+export function drawNonTraversableCells(traversableCells, cpt, visuals = true,
   notTraverableColor = 0xff8c00, alpha = 0.4) {
   clearSprites(tagpro.renderer.nonTraversableCellSprites);
-  createNonTraversableCellSprites(traversableCells, cpt, notTraverableColor, alpha);
+  if (visuals) {
+    createNonTraversableCellSprites(traversableCells, cpt, notTraverableColor, alpha);
+  }
   drawSprites(tagpro.renderer.nonTraversableCellSprites);
 }

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -43,6 +43,24 @@ export function createPathSprites(path, cpt, hexColor, alpha) {
   });
 }
 
+function createTraversableCellSprites(
+  traversableCells, cpt, traversableColor, notTraverableColor, alpha) {
+  tagpro.renderer.traversableCellSprites = [];
+  const pixelsPerCell = PIXELS_PER_TILE / cpt;
+  for (let x = 0; x < traversableCells.length; x++) {
+    for (let y = 0; y < traversableCells[0].length; y++) {
+      const rect = new PIXI.Graphics();
+      rect.beginFill(traversableCells[x][y] ? traversableColor : notTraverableColor).drawRect(
+        x * pixelsPerCell, // x coordinate
+        y * pixelsPerCell, // y coordinate
+        pixelsPerCell, // width
+        pixelsPerCell, // height
+      ).alpha = alpha;
+      tagpro.renderer.traversableCellSprites.push(rect);
+    }
+  }
+}
+
 /*
  * Used to draw the bot's planned path. Takes in a reference to a list of cells returned by
  * getShortestPath() in helpers/path.js and the cpt used when calculating shortest path, and draws
@@ -54,3 +72,9 @@ export function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
   drawSprites(tagpro.renderer.pathSprites); // put the PIXI.Graphics objects on the map
 }
 
+export function drawTraversableCells(traversableCells, cpt, traversableColor = 0x0000ff,
+  notTraverableColor = 0xff0000, alpha = 0.1) {
+  clearSprites(tagpro.renderer.traversableCellSprites);
+  createTraversableCellSprites(traversableCells, cpt, traversableColor, notTraverableColor, alpha);
+  drawSprites(tagpro.renderer.traversableCellSprites);
+}

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -14,6 +14,7 @@
  * that was previously drawn.
  */
 import { PIXELS_PER_TILE } from '../constants';
+import { visualMode } from '../utils/interface';
 import { clearSprites, drawSprites } from './utils';
 
 /*
@@ -69,18 +70,18 @@ function createNonTraversableCellSprites(
  * getShortestPath() in helpers/path.js and the cpt used when calculating shortest path, and draws
  * the corresponding cells in green on the map.
  */
-export function drawPlannedPath(path, cpt, visuals = true, hexColor = 0x00ff00, alpha = 0.25) {
+export function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
   clearSprites(tagpro.renderer.pathSprites); // clear the previous path from the map
-  if (visuals) {
+  if (visualMode()) {
     createPathSprites(path, cpt, hexColor, alpha); // create the PIXI.Graphics objecs we're drawing
   }
   drawSprites(tagpro.renderer.pathSprites); // put the PIXI.Graphics objects on the map
 }
 
-export function drawNonTraversableCells(traversableCells, cpt, visuals = true,
-  notTraversableColor = 0xff8c00, alpha = 0.4) {
+export function drawNonTraversableCells(traversableCells, cpt, notTraversableColor = 0xff8c00,
+  alpha = 0.4) {
   clearSprites(tagpro.renderer.nonTraversableCellSprites);
-  if (visuals) {
+  if (visualMode()) {
     createNonTraversableCellSprites(traversableCells, cpt, notTraversableColor, alpha);
   }
   drawSprites(tagpro.renderer.nonTraversableCellSprites);

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -43,20 +43,22 @@ export function createPathSprites(path, cpt, hexColor, alpha) {
   });
 }
 
-function createTraversableCellSprites(
-  traversableCells, cpt, traversableColor, notTraverableColor, alpha) {
-  tagpro.renderer.traversableCellSprites = [];
+function createNonTraversableCellSprites(
+  traversableCells, cpt, notTraverableColor, alpha) {
+  tagpro.renderer.nonTraversableCellSprites = [];
   const pixelsPerCell = PIXELS_PER_TILE / cpt;
   for (let x = 0; x < traversableCells.length; x++) {
     for (let y = 0; y < traversableCells[0].length; y++) {
-      const rect = new PIXI.Graphics();
-      rect.beginFill(traversableCells[x][y] ? traversableColor : notTraverableColor).drawRect(
-        x * pixelsPerCell, // x coordinate
-        y * pixelsPerCell, // y coordinate
-        pixelsPerCell, // width
-        pixelsPerCell, // height
-      ).alpha = alpha;
-      tagpro.renderer.traversableCellSprites.push(rect);
+      if (!traversableCells[x][y]) { // if cell is non traversable
+        const rect = new PIXI.Graphics();
+        rect.beginFill(notTraverableColor).drawRect(
+          x * pixelsPerCell, // x coordinate
+          y * pixelsPerCell, // y coordinate
+          pixelsPerCell, // width
+          pixelsPerCell, // height
+        ).alpha = alpha;
+        tagpro.renderer.nonTraversableCellSprites.push(rect);
+      }
     }
   }
 }
@@ -72,9 +74,9 @@ export function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
   drawSprites(tagpro.renderer.pathSprites); // put the PIXI.Graphics objects on the map
 }
 
-export function drawTraversableCells(traversableCells, cpt, traversableColor = 0x0000ff,
-  notTraverableColor = 0xff0000, alpha = 0.1) {
-  clearSprites(tagpro.renderer.traversableCellSprites);
-  createTraversableCellSprites(traversableCells, cpt, traversableColor, notTraverableColor, alpha);
-  drawSprites(tagpro.renderer.traversableCellSprites);
+export function drawNonTraversableCells(traversableCells, cpt,
+  notTraverableColor = 0xff8c00, alpha = 0.4) {
+  clearSprites(tagpro.renderer.nonTraversableCellSprites);
+  createNonTraversableCellSprites(traversableCells, cpt, notTraverableColor, alpha);
+  drawSprites(tagpro.renderer.nonTraversableCellSprites);
 }

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -13,7 +13,7 @@
  * path, we erase any path that was previously drawn.
  */
 import { PIXELS_PER_TILE } from '../constants';
-import { visualsOn } from '../utils/interface';
+import { areVisualsOn } from '../utils/interface';
 import { clearSprites, drawSprites } from './utils';
 
 let pathSprites = [];
@@ -83,7 +83,7 @@ function createNonTraversableCellSprites(
  */
 export function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
   pathSprites = clearSprites(pathSprites); // clear the previous path from the map
-  if (visualsOn()) {
+  if (areVisualsOn()) {
     createPathSprites(path, cpt, hexColor, alpha); // create the PIXI.Graphics objecs we're drawing
   }
   drawSprites(pathSprites); // put the PIXI.Graphics objects on the map
@@ -92,7 +92,7 @@ export function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
 export function drawNonTraversableCells(traversableCells, cpt, notTraversableColor = 0xff8c00,
   alpha = 0.4) {
   nonTraversableCellSprites = clearSprites(nonTraversableCellSprites);
-  if (visualsOn()) {
+  if (areVisualsOn()) {
     createNonTraversableCellSprites(traversableCells, cpt, notTraversableColor, alpha);
   }
   drawSprites(nonTraversableCellSprites);

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -14,7 +14,7 @@
  * that was previously drawn.
  */
 import { PIXELS_PER_TILE } from '../constants';
-import { visualMode } from '../utils/interface';
+import { visualsOn } from '../utils/interface';
 import { clearSprites, drawSprites } from './utils';
 
 /*
@@ -72,7 +72,7 @@ function createNonTraversableCellSprites(
  */
 export function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
   clearSprites(tagpro.renderer.pathSprites); // clear the previous path from the map
-  if (visualMode()) {
+  if (visualsOn()) {
     createPathSprites(path, cpt, hexColor, alpha); // create the PIXI.Graphics objecs we're drawing
   }
   drawSprites(tagpro.renderer.pathSprites); // put the PIXI.Graphics objects on the map
@@ -81,7 +81,7 @@ export function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
 export function drawNonTraversableCells(traversableCells, cpt, notTraversableColor = 0xff8c00,
   alpha = 0.4) {
   clearSprites(tagpro.renderer.nonTraversableCellSprites);
-  if (visualMode()) {
+  if (visualsOn()) {
     createNonTraversableCellSprites(traversableCells, cpt, notTraversableColor, alpha);
   }
   drawSprites(tagpro.renderer.nonTraversableCellSprites);

--- a/src/draw/utils.js
+++ b/src/draw/utils.js
@@ -1,0 +1,21 @@
+/*
+ * Iterates over each PIXI.Graphics object in sprites and adds it to the background
+ */
+export function drawSprites(sprites) {
+  sprites.forEach(sprite => {
+    tagpro.renderer.layers.background.addChild(sprite);
+  });
+}
+
+
+/*
+ * Iterates through the sprites provided to the function, and removes them from
+ * tagpro.renderer.layers.background
+ */
+export function clearSprites(sprites) {
+  if (sprites) {
+    sprites.forEach(sprite => {
+      tagpro.renderer.layers.background.removeChild(sprite);
+    });
+  }
+}

--- a/src/draw/utils.js
+++ b/src/draw/utils.js
@@ -10,13 +10,14 @@ export function drawSprites(sprites) {
 
 /*
  * Iterates through the sprites provided to the function, and removes them from
- * tagpro.renderer.layers.background
+ * tagpro.renderer.layers.background. Returns the new sprites object
  */
 export function clearSprites(sprites) {
   if (sprites) {
     sprites.forEach(sprite => {
       tagpro.renderer.layers.background.removeChild(sprite);
     });
-    sprites.splice(0, sprites.length);
+    return [];
   }
+  return sprites;
 }

--- a/src/draw/utils.js
+++ b/src/draw/utils.js
@@ -17,5 +17,6 @@ export function clearSprites(sprites) {
     sprites.forEach(sprite => {
       tagpro.renderer.layers.background.removeChild(sprite);
     });
+    sprites.splice(0, sprites.length);
   }
 }

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -44,11 +44,8 @@ export function onKeyDown(event) {
   }
   if (event.keyCode === KEY_CODES.v) { // toggle visuals
     VISUALS = !VISUALS;
-    if (VISUALS) {
-      chat('Visuals enabled!');
-    } else {
-      chat('Visuals disabled!');
-    }
+    const chatMsg = visualMode() ? 'enabled' : 'disabled';
+    chat(`Visuals ${chatMsg}`);
   }
 }
 

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -16,6 +16,7 @@ export function chat(chatMessage) {
 }
 
 let AUTONOMOUS = true;
+let VISUALS = true;
 
 export function isAutonomous() {
   return AUTONOMOUS;
@@ -25,6 +26,7 @@ export function onKeyDown(event) {
   // If letter pressed is Q, toggle autonomous controls
   if (event.keyCode === 81) {
     AUTONOMOUS = !AUTONOMOUS;
+    VISUALS = AUTONOMOUS;
     tagpro.sendKeyPress('up', true);
     tagpro.sendKeyPress('down', true);
     tagpro.sendKeyPress('left', true);
@@ -32,6 +34,14 @@ export function onKeyDown(event) {
     const autonomyMode = AUTONOMOUS ? 'AUTONOMOUS' : 'MANUAL';
     chat(`Autonomy Mode updated: now ${autonomyMode}!`);
     setTimeout(() => { console.log(`Autonomy status: ${AUTONOMOUS}`); }, 200);
+  }
+  if (event.keyCode === 86) { // 'v'
+    VISUALS = !VISUALS;
+    if (VISUALS) {
+      chat('Visuals enabled!');
+    } else {
+      chat('Visuals disabled!');
+    }
   }
 }
 

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -22,6 +22,10 @@ export function isAutonomous() {
   return AUTONOMOUS;
 }
 
+export function visualMode() {
+  return VISUALS;
+}
+
 export function onKeyDown(event) {
   // If letter pressed is Q, toggle autonomous controls
   if (event.keyCode === 81) {

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -25,7 +25,7 @@ export function isAutonomous() {
   return autonomous;
 }
 
-export function visualsOn() {
+export function areVisualsOn() {
   return visuals;
 }
 

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -18,33 +18,33 @@ export function chat(chatMessage) {
   }
 }
 
-let AUTONOMOUS = true;
-let VISUALS = true;
+let autonomous = true;
+let visuals = true;
 
 export function isAutonomous() {
-  return AUTONOMOUS;
+  return autonomous;
 }
 
-export function visualMode() {
-  return VISUALS;
+export function visualsOn() {
+  return visuals;
 }
 
 export function onKeyDown(event) {
   // If letter pressed is Q, toggle autonomous controls
   if (event.keyCode === KEY_CODES.q) {
-    AUTONOMOUS = !AUTONOMOUS;
-    VISUALS = AUTONOMOUS;
+    autonomous = !autonomous;
+    visuals = autonomous;
     tagpro.sendKeyPress('up', true);
     tagpro.sendKeyPress('down', true);
     tagpro.sendKeyPress('left', true);
     tagpro.sendKeyPress('right', true);
-    const autonomyMode = AUTONOMOUS ? 'AUTONOMOUS' : 'MANUAL';
+    const autonomyMode = autonomous ? 'autonomous' : 'MANUAL';
     chat(`Autonomy Mode updated: now ${autonomyMode}!`);
-    setTimeout(() => { console.log(`Autonomy status: ${AUTONOMOUS}`); }, 200);
+    setTimeout(() => { console.log(`Autonomy status: ${autonomous}`); }, 200);
   }
   if (event.keyCode === KEY_CODES.v) { // toggle visuals
-    VISUALS = !VISUALS;
-    const chatMsg = visualMode() ? 'enabled' : 'disabled';
+    visuals = !visuals;
+    const chatMsg = visuals ? 'enabled' : 'disabled';
     chat(`Visuals ${chatMsg}`);
   }
 }

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -1,3 +1,6 @@
+
+const KEY_CODES = { q: 81, v: 86 };
+
 // Stole this function to send chat messages
 let lastMessage = 0;
 export function chat(chatMessage) {
@@ -28,7 +31,7 @@ export function visualMode() {
 
 export function onKeyDown(event) {
   // If letter pressed is Q, toggle autonomous controls
-  if (event.keyCode === 81) {
+  if (event.keyCode === KEY_CODES.q) {
     AUTONOMOUS = !AUTONOMOUS;
     VISUALS = AUTONOMOUS;
     tagpro.sendKeyPress('up', true);
@@ -39,7 +42,7 @@ export function onKeyDown(event) {
     chat(`Autonomy Mode updated: now ${autonomyMode}!`);
     setTimeout(() => { console.log(`Autonomy status: ${AUTONOMOUS}`); }, 200);
   }
-  if (event.keyCode === 86) { // 'v'
+  if (event.keyCode === KEY_CODES.v) { // toggle visuals
     VISUALS = !VISUALS;
     if (VISUALS) {
       chat('Visuals enabled!');

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -1,5 +1,5 @@
 
-const KEY_CODES = { q: 81, v: 86 };
+const KEY_CODES = { Q: 81, V: 86 };
 
 // Stole this function to send chat messages
 let lastMessage = 0;
@@ -31,7 +31,7 @@ export function areVisualsOn() {
 
 export function onKeyDown(event) {
   // If letter pressed is Q, toggle autonomous controls
-  if (event.keyCode === KEY_CODES.q) {
+  if (event.keyCode === KEY_CODES.Q) {
     autonomous = !autonomous;
     visuals = autonomous;
     tagpro.sendKeyPress('up', true);
@@ -42,7 +42,7 @@ export function onKeyDown(event) {
     chat(`Autonomy Mode updated: now ${autonomyMode}!`);
     setTimeout(() => { console.log(`Autonomy status: ${autonomous}`); }, 200);
   }
-  if (event.keyCode === KEY_CODES.v) { // toggle visuals
+  if (event.keyCode === KEY_CODES.V) { // toggle visuals
     visuals = !visuals;
     const chatMsg = visuals ? 'enabled' : 'disabled';
     chat(`Visuals ${chatMsg}`);

--- a/test/map.spec.js
+++ b/test/map.spec.js
@@ -161,7 +161,7 @@ test('test getSubarrayFrom2dArray', t => {
   t.end();
 });
 
-test('test traversableCellsInTile', t => {
+test('test traversableCellsInTile returns correct cells for each tile', t => {
   let expected = [
     [1, 1, 1, 1],
     [1, 1, 1, 1],

--- a/test/visualizePath.spec.js
+++ b/test/visualizePath.spec.js
@@ -34,7 +34,7 @@ test('clearSprites() calls addChild for each sprite', t => {
   t.end();
 });
 
-test('drawPlannedPath() calls the right functions with visualMode on', t => {
+test('drawPlannedPath() calls the right functions with visualsOn on', t => {
   const mockClearSprites = sinon.spy();
   const mockCreatePathSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
@@ -43,7 +43,7 @@ test('drawPlannedPath() calls the right functions with visualMode on', t => {
   DrawingRewireAPI.__Rewire__('clearSprites', mockClearSprites);
   DrawingRewireAPI.__Rewire__('createPathSprites', mockCreatePathSprites);
   DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
-  DrawingRewireAPI.__Rewire__('visualMode', mockVisual);
+  DrawingRewireAPI.__Rewire__('visualsOn', mockVisual);
 
   drawPlannedPath('path', 'cpt', 'hexColor', 'alpha');
 
@@ -53,7 +53,7 @@ test('drawPlannedPath() calls the right functions with visualMode on', t => {
   t.true(mockDrawSprites.calledOnce);
 
   mockVisual = sinon.stub().returns(false);
-  DrawingRewireAPI.__Rewire__('visualMode', mockVisual);
+  DrawingRewireAPI.__Rewire__('visualsOn', mockVisual);
   drawPlannedPath('path', 'cpt', 'hexColor', 'alpha');
 
   t.true(mockVisual.calledOnce);
@@ -77,7 +77,7 @@ test('drawNonTraversableCells() calls the right functions', t => {
   DrawingRewireAPI.__Rewire__('createNonTraversableCellSprites',
     mockCreateNonTraversableCellSprites);
   DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
-  DrawingRewireAPI.__Rewire__('visualMode', mockVisual);
+  DrawingRewireAPI.__Rewire__('visualsOn', mockVisual);
 
   drawNonTraversableCells('traversableCells', 'cpt', 'hexColor', 'alpha');
 
@@ -88,7 +88,7 @@ test('drawNonTraversableCells() calls the right functions', t => {
   t.true(mockDrawSprites.calledOnce);
 
   mockVisual = sinon.stub().returns(false);
-  DrawingRewireAPI.__Rewire__('visualMode', mockVisual);
+  DrawingRewireAPI.__Rewire__('visualsOn', mockVisual);
   drawNonTraversableCells('traversableCells', 'cpt', 'hexColor', 'alpha');
 
   t.true(mockVisual.calledOnce);
@@ -99,6 +99,6 @@ test('drawNonTraversableCells() calls the right functions', t => {
   DrawingRewireAPI.__ResetDependency__('clearSprites');
   DrawingRewireAPI.__ResetDependency__('createPathSprites');
   DrawingRewireAPI.__ResetDependency__('drawSprites');
-  DrawingRewireAPI.__ResetDependency__('visualMode');
+  DrawingRewireAPI.__ResetDependency__('visualsOn');
   t.end();
 });

--- a/test/visualizePath.spec.js
+++ b/test/visualizePath.spec.js
@@ -42,7 +42,7 @@ test('drawPlannedPath() calls the right functions', t => {
   RewireAPI.__Rewire__('createPathSprites', mockCreatePathSprites);
   RewireAPI.__Rewire__('drawSprites', mockdrawSprites);
 
-  drawPlannedPath('path', 'cpt', true, 'hexColor', 'alpha');
+  drawPlannedPath('path', 'cpt', 'hexColor', 'alpha');
 
   t.true(mockclearSprites.calledOnce);
   t.true(mockCreatePathSprites.calledWith('path', 'cpt', 'hexColor', 'alpha'));

--- a/test/visualizePath.spec.js
+++ b/test/visualizePath.spec.js
@@ -1,9 +1,10 @@
 import sinon from 'sinon';
 import test from 'tape';
 
-import drawPlannedPath, { clearRects, drawRects } from '../src/draw/visualizePath';
+import { drawPlannedPath, __RewireAPI__ as RewireAPI } from '../src/draw/drawings';
+import { clearSprites, drawSprites } from '../src/draw/utils';
 
-test('clearRects() calls removeChild for each sprite', t => {
+test('clearSprites() calls removeChild for each sprite', t => {
   const mockRemoveChild = sinon.spy();
   global.tagpro = {
     renderer: {
@@ -12,13 +13,13 @@ test('clearRects() calls removeChild for each sprite', t => {
     },
   };
 
-  clearRects();
+  clearSprites(tagpro.renderer.pathSprites);
 
   t.true(mockRemoveChild.calledThrice);
   t.end();
 });
 
-test('clearRects() calls addChild for each sprite', t => {
+test('clearSprites() calls addChild for each sprite', t => {
   const mockAddChild = sinon.spy();
   global.tagpro = {
     renderer: {
@@ -27,28 +28,28 @@ test('clearRects() calls addChild for each sprite', t => {
     },
   };
 
-  drawRects();
+  drawSprites(tagpro.renderer.pathSprites);
 
   t.true(mockAddChild.calledThrice);
   t.end();
 });
 
 test('drawPlannedPath() calls the right functions', t => {
-  const mockClearRects = sinon.spy();
+  const mockclearSprites = sinon.spy();
   const mockCreatePathSprites = sinon.spy();
-  const mockDrawRects = sinon.spy();
-  drawPlannedPath.__Rewire__('clearRects', mockClearRects);
-  drawPlannedPath.__Rewire__('createPathSprites', mockCreatePathSprites);
-  drawPlannedPath.__Rewire__('drawRects', mockDrawRects);
+  const mockdrawSprites = sinon.spy();
+  RewireAPI.__Rewire__('clearSprites', mockclearSprites);
+  RewireAPI.__Rewire__('createPathSprites', mockCreatePathSprites);
+  RewireAPI.__Rewire__('drawSprites', mockdrawSprites);
 
-  drawPlannedPath('path', 'cpt', 'hexColor', 'alpha');
+  drawPlannedPath('path', 'cpt', true, 'hexColor', 'alpha');
 
-  t.true(mockClearRects.calledOnce);
+  t.true(mockclearSprites.calledOnce);
   t.true(mockCreatePathSprites.calledWith('path', 'cpt', 'hexColor', 'alpha'));
-  t.true(mockDrawRects.calledOnce);
+  t.true(mockdrawSprites.calledOnce);
 
-  drawPlannedPath.__ResetDependency__('clearRects');
-  drawPlannedPath.__ResetDependency__('createPathSprites');
-  drawPlannedPath.__ResetDependency__('drawRects');
+  RewireAPI.__ResetDependency__('clearSprites');
+  RewireAPI.__ResetDependency__('createPathSprites');
+  RewireAPI.__ResetDependency__('drawSprites');
   t.end();
 });

--- a/test/visualizePath.spec.js
+++ b/test/visualizePath.spec.js
@@ -43,7 +43,7 @@ test('clearSprites() calls addChild for each sprite', t => {
   t.end();
 });
 
-test('drawPlannedPath() calls the right functions with visualsOn on', t => {
+test('drawPlannedPath() calls the right functions with areVisualsOn false', t => {
   const mockClearSprites = sinon.spy();
   const mockCreatePathSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
@@ -52,7 +52,7 @@ test('drawPlannedPath() calls the right functions with visualsOn on', t => {
   DrawingRewireAPI.__Rewire__('clearSprites', mockClearSprites);
   DrawingRewireAPI.__Rewire__('createPathSprites', mockCreatePathSprites);
   DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
-  DrawingRewireAPI.__Rewire__('visualsOn', mockVisual);
+  DrawingRewireAPI.__Rewire__('areVisualsOn', mockVisual);
 
   drawPlannedPath('path', 'cpt', 'hexColor', 'alpha');
 
@@ -64,11 +64,11 @@ test('drawPlannedPath() calls the right functions with visualsOn on', t => {
   DrawingRewireAPI.__ResetDependency__('clearSprites');
   DrawingRewireAPI.__ResetDependency__('createPathSprites');
   DrawingRewireAPI.__ResetDependency__('drawSprites');
-  DrawingRewireAPI.__ResetDependency__('visualsOn');
+  DrawingRewireAPI.__ResetDependency__('areVisualsOn');
   t.end();
 });
 
-test('drawPlannedPath() calls the right functions with visualsOn off', t => {
+test('drawPlannedPath() calls the right functions with areVisualsOn false', t => {
   const mockClearSprites = sinon.spy();
   const mockCreatePathSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
@@ -77,7 +77,7 @@ test('drawPlannedPath() calls the right functions with visualsOn off', t => {
   DrawingRewireAPI.__Rewire__('clearSprites', mockClearSprites);
   DrawingRewireAPI.__Rewire__('createPathSprites', mockCreatePathSprites);
   DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
-  DrawingRewireAPI.__Rewire__('visualsOn', mockVisual);
+  DrawingRewireAPI.__Rewire__('areVisualsOn', mockVisual);
 
   drawPlannedPath('path', 'cpt', 'hexColor', 'alpha');
 
@@ -89,11 +89,11 @@ test('drawPlannedPath() calls the right functions with visualsOn off', t => {
   DrawingRewireAPI.__ResetDependency__('clearSprites');
   DrawingRewireAPI.__ResetDependency__('createPathSprites');
   DrawingRewireAPI.__ResetDependency__('drawSprites');
-  DrawingRewireAPI.__ResetDependency__('visualsOn');
+  DrawingRewireAPI.__ResetDependency__('areVisualsOn');
   t.end();
 });
 
-test('drawNonTraversableCells() calls the right functions with visualsOn on', t => {
+test('drawNonTraversableCells() calls the right functions with areVisualsOn true', t => {
   const mockClearSprites = sinon.spy();
   const mockCreateNonTraversableCellSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
@@ -103,7 +103,7 @@ test('drawNonTraversableCells() calls the right functions with visualsOn on', t 
   DrawingRewireAPI.__Rewire__('createNonTraversableCellSprites',
     mockCreateNonTraversableCellSprites);
   DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
-  DrawingRewireAPI.__Rewire__('visualsOn', mockVisual);
+  DrawingRewireAPI.__Rewire__('areVisualsOn', mockVisual);
 
   drawNonTraversableCells('traversableCells', 'cpt', 'hexColor', 'alpha');
 
@@ -116,11 +116,11 @@ test('drawNonTraversableCells() calls the right functions with visualsOn on', t 
   DrawingRewireAPI.__ResetDependency__('clearSprites');
   DrawingRewireAPI.__ResetDependency__('createPathSprites');
   DrawingRewireAPI.__ResetDependency__('drawSprites');
-  DrawingRewireAPI.__ResetDependency__('visualsOn');
+  DrawingRewireAPI.__ResetDependency__('areVisualsOn');
   t.end();
 });
 
-test('drawNonTraversableCells() calls the right functions with visualsOn off', t => {
+test('drawNonTraversableCells() calls the right functions with areVisualsOn false', t => {
   const mockClearSprites = sinon.spy();
   const mockCreateNonTraversableCellSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
@@ -130,7 +130,7 @@ test('drawNonTraversableCells() calls the right functions with visualsOn off', t
   DrawingRewireAPI.__Rewire__('createNonTraversableCellSprites',
     mockCreateNonTraversableCellSprites);
   DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
-  DrawingRewireAPI.__Rewire__('visualsOn', mockVisual);
+  DrawingRewireAPI.__Rewire__('areVisualsOn', mockVisual);
 
   drawNonTraversableCells('traversableCells', 'cpt', 'hexColor', 'alpha');
 
@@ -142,6 +142,6 @@ test('drawNonTraversableCells() calls the right functions with visualsOn off', t
   DrawingRewireAPI.__ResetDependency__('clearSprites');
   DrawingRewireAPI.__ResetDependency__('createPathSprites');
   DrawingRewireAPI.__ResetDependency__('drawSprites');
-  DrawingRewireAPI.__ResetDependency__('visualsOn');
+  DrawingRewireAPI.__ResetDependency__('areVisualsOn');
   t.end();
 });

--- a/test/visualizePath.spec.js
+++ b/test/visualizePath.spec.js
@@ -47,7 +47,7 @@ test('drawPlannedPath() calls the right functions with visualsOn on', t => {
   const mockClearSprites = sinon.spy();
   const mockCreatePathSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
-  let mockVisual = sinon.stub().returns(true);
+  const mockVisual = sinon.stub().returns(true);
 
   DrawingRewireAPI.__Rewire__('clearSprites', mockClearSprites);
   DrawingRewireAPI.__Rewire__('createPathSprites', mockCreatePathSprites);
@@ -61,26 +61,43 @@ test('drawPlannedPath() calls the right functions with visualsOn on', t => {
   t.true(mockCreatePathSprites.calledWith('path', 'cpt', 'hexColor', 'alpha'));
   t.true(mockDrawSprites.calledOnce);
 
-  mockVisual = sinon.stub().returns(false);
+  DrawingRewireAPI.__ResetDependency__('clearSprites');
+  DrawingRewireAPI.__ResetDependency__('createPathSprites');
+  DrawingRewireAPI.__ResetDependency__('drawSprites');
+  DrawingRewireAPI.__ResetDependency__('visualsOn');
+  t.end();
+});
+
+test('drawPlannedPath() calls the right functions with visualsOn off', t => {
+  const mockClearSprites = sinon.spy();
+  const mockCreatePathSprites = sinon.spy();
+  const mockDrawSprites = sinon.spy();
+  const mockVisual = sinon.stub().returns(false);
+
+  DrawingRewireAPI.__Rewire__('clearSprites', mockClearSprites);
+  DrawingRewireAPI.__Rewire__('createPathSprites', mockCreatePathSprites);
+  DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
   DrawingRewireAPI.__Rewire__('visualsOn', mockVisual);
+
   drawPlannedPath('path', 'cpt', 'hexColor', 'alpha');
 
   t.true(mockVisual.calledOnce);
-  t.true(mockClearSprites.calledTwice);
-  t.true(mockCreatePathSprites.calledOnce);
-  t.true(mockDrawSprites.calledTwice);
+  t.true(mockClearSprites.calledOnce);
+  t.false(mockCreatePathSprites.called);
+  t.true(mockDrawSprites.calledOnce);
 
   DrawingRewireAPI.__ResetDependency__('clearSprites');
   DrawingRewireAPI.__ResetDependency__('createPathSprites');
   DrawingRewireAPI.__ResetDependency__('drawSprites');
+  DrawingRewireAPI.__ResetDependency__('visualsOn');
   t.end();
 });
 
-test('drawNonTraversableCells() calls the right functions', t => {
+test('drawNonTraversableCells() calls the right functions with visualsOn on', t => {
   const mockClearSprites = sinon.spy();
   const mockCreateNonTraversableCellSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
-  let mockVisual = sinon.stub().returns(true);
+  const mockVisual = sinon.stub().returns(true);
 
   DrawingRewireAPI.__Rewire__('clearSprites', mockClearSprites);
   DrawingRewireAPI.__Rewire__('createNonTraversableCellSprites',
@@ -96,14 +113,31 @@ test('drawNonTraversableCells() calls the right functions', t => {
     'traversableCells', 'cpt', 'hexColor', 'alpha'));
   t.true(mockDrawSprites.calledOnce);
 
-  mockVisual = sinon.stub().returns(false);
+  DrawingRewireAPI.__ResetDependency__('clearSprites');
+  DrawingRewireAPI.__ResetDependency__('createPathSprites');
+  DrawingRewireAPI.__ResetDependency__('drawSprites');
+  DrawingRewireAPI.__ResetDependency__('visualsOn');
+  t.end();
+});
+
+test('drawNonTraversableCells() calls the right functions with visualsOn off', t => {
+  const mockClearSprites = sinon.spy();
+  const mockCreateNonTraversableCellSprites = sinon.spy();
+  const mockDrawSprites = sinon.spy();
+  const mockVisual = sinon.stub().returns(false);
+
+  DrawingRewireAPI.__Rewire__('clearSprites', mockClearSprites);
+  DrawingRewireAPI.__Rewire__('createNonTraversableCellSprites',
+    mockCreateNonTraversableCellSprites);
+  DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
   DrawingRewireAPI.__Rewire__('visualsOn', mockVisual);
+
   drawNonTraversableCells('traversableCells', 'cpt', 'hexColor', 'alpha');
 
   t.true(mockVisual.calledOnce);
-  t.true(mockClearSprites.calledTwice);
-  t.true(mockCreateNonTraversableCellSprites.calledOnce);
-  t.true(mockDrawSprites.calledTwice);
+  t.true(mockClearSprites.calledOnce);
+  t.false(mockCreateNonTraversableCellSprites.called);
+  t.true(mockDrawSprites.calledOnce);
 
   DrawingRewireAPI.__ResetDependency__('clearSprites');
   DrawingRewireAPI.__ResetDependency__('createPathSprites');

--- a/test/visualizePath.spec.js
+++ b/test/visualizePath.spec.js
@@ -38,15 +38,28 @@ test('drawPlannedPath() calls the right functions with visualMode on', t => {
   const mockClearSprites = sinon.spy();
   const mockCreatePathSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
+  let mockVisual = sinon.stub().returns(true);
+
   DrawingRewireAPI.__Rewire__('clearSprites', mockClearSprites);
   DrawingRewireAPI.__Rewire__('createPathSprites', mockCreatePathSprites);
   DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
+  DrawingRewireAPI.__Rewire__('visualMode', mockVisual);
 
   drawPlannedPath('path', 'cpt', 'hexColor', 'alpha');
 
+  t.true(mockVisual.calledOnce);
   t.true(mockClearSprites.calledOnce);
   t.true(mockCreatePathSprites.calledWith('path', 'cpt', 'hexColor', 'alpha'));
   t.true(mockDrawSprites.calledOnce);
+
+  mockVisual = sinon.stub().returns(false);
+  DrawingRewireAPI.__Rewire__('visualMode', mockVisual);
+  drawPlannedPath('path', 'cpt', 'hexColor', 'alpha');
+
+  t.true(mockVisual.calledOnce);
+  t.true(mockClearSprites.calledTwice);
+  t.true(mockCreatePathSprites.calledOnce);
+  t.true(mockDrawSprites.calledTwice);
 
   DrawingRewireAPI.__ResetDependency__('clearSprites');
   DrawingRewireAPI.__ResetDependency__('createPathSprites');
@@ -59,6 +72,7 @@ test('drawNonTraversableCells() calls the right functions', t => {
   const mockCreateNonTraversableCellSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
   let mockVisual = sinon.stub().returns(true);
+
   DrawingRewireAPI.__Rewire__('clearSprites', mockClearSprites);
   DrawingRewireAPI.__Rewire__('createNonTraversableCellSprites',
     mockCreateNonTraversableCellSprites);
@@ -67,7 +81,7 @@ test('drawNonTraversableCells() calls the right functions', t => {
 
   drawNonTraversableCells('traversableCells', 'cpt', 'hexColor', 'alpha');
 
-  t.true(mockVisual.calledOnce); // THIS LINE FAILS
+  t.true(mockVisual.calledOnce);
   t.true(mockClearSprites.calledOnce);
   t.true(mockCreateNonTraversableCellSprites.calledWith(
     'traversableCells', 'cpt', 'hexColor', 'alpha'));
@@ -77,9 +91,9 @@ test('drawNonTraversableCells() calls the right functions', t => {
   DrawingRewireAPI.__Rewire__('visualMode', mockVisual);
   drawNonTraversableCells('traversableCells', 'cpt', 'hexColor', 'alpha');
 
-  t.true(mockVisual.calledOnce); // THIS LINE FAILS
+  t.true(mockVisual.calledOnce);
   t.true(mockClearSprites.calledTwice);
-  t.true(mockCreateNonTraversableCellSprites.calledOnce)
+  t.true(mockCreateNonTraversableCellSprites.calledOnce);
   t.true(mockDrawSprites.calledTwice);
 
   DrawingRewireAPI.__ResetDependency__('clearSprites');

--- a/test/visualizePath.spec.js
+++ b/test/visualizePath.spec.js
@@ -6,30 +6,39 @@ import { clearSprites, drawSprites } from '../src/draw/utils';
 
 test('clearSprites() calls removeChild for each sprite', t => {
   const mockRemoveChild = sinon.spy();
+  const pathSprites = [1, 2, 3];
   global.tagpro = {
     renderer: {
-      pathSprites: [1, 2, 3],
       layers: { background: { removeChild: mockRemoveChild } },
     },
   };
-
-  clearSprites(tagpro.renderer.pathSprites);
-
+  clearSprites(pathSprites);
   t.true(mockRemoveChild.calledThrice);
+  t.end();
+});
+
+test('clearSprites() returns an empty array', t => {
+  const mockRemoveChild = sinon.spy();
+  let pathSprites = [1, 2, 3];
+  global.tagpro = {
+    renderer: {
+      layers: { background: { removeChild: mockRemoveChild } },
+    },
+  };
+  pathSprites = clearSprites(pathSprites);
+  t.is(pathSprites.length, 0);
   t.end();
 });
 
 test('clearSprites() calls addChild for each sprite', t => {
   const mockAddChild = sinon.spy();
+  const pathSprites = [1, 2, 3];
   global.tagpro = {
     renderer: {
-      pathSprites: [1, 2, 3],
       layers: { background: { addChild: mockAddChild } },
     },
   };
-
-  drawSprites(tagpro.renderer.pathSprites);
-
+  drawSprites(pathSprites);
   t.true(mockAddChild.calledThrice);
   t.end();
 });


### PR DESCRIPTION
Closes #75 

Now with gif

![gif](https://user-images.githubusercontent.com/8933701/28757934-6dd9d5e2-7542-11e7-9299-add52900daf2.gif)

Three main things accomplished:

1. Separaed drawing code into multiple files, and made code more reusable
2. Draw cells the bot considers "non-tranversable" a light orange color
3. Allow the user to toggle visuals using the 'v' key
