### PR TITLE
91: edit traversable API

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,5 +1,5 @@
-import { PIXELS_PER_TILE } from './constants';
-import { getTraversableCells } from './helpers/map';
+import { PPTL } from './constants';
+import { getMapTraversabilityInCells } from './helpers/map';
 import {
   findMyEndzone,
   findEnemyEndzone,
@@ -67,16 +67,15 @@ function getSeek() {
 
   // Version for attempting path-planning
   const gridPosition = {
-    x: Math.floor((me.x + 20) / PIXELS_PER_TILE),
-    y: Math.floor((me.y + 20) / PIXELS_PER_TILE),
+    x: Math.floor((me.x + 20) / PPTL),
+    y: Math.floor((me.y + 20) / PPTL),
   };
   const gridTarget = {
-    x: Math.floor(goal.x / PIXELS_PER_TILE),
-    y: Math.floor(goal.y / PIXELS_PER_TILE),
+    x: Math.floor(goal.x / PPTL),
+    y: Math.floor(goal.y / PPTL),
   };
-  const cellsPerTile = 1;
-  const traversableCells = getTraversableCells(cellsPerTile, tagpro.map);
-  drawNonTraversableCells(traversableCells, cellsPerTile);
+  const traversableCells = getMapTraversabilityInCells(tagpro.map);
+  drawNonTraversableCells(traversableCells);
   const shortestPath = getShortestPath(
     gridPosition.x,
     gridPosition.y,
@@ -89,11 +88,11 @@ function getSeek() {
     gridPosition.y,
     shortestPath,
   );
-  seekToward.x *= PIXELS_PER_TILE;
-  seekToward.y *= PIXELS_PER_TILE;
+  seekToward.x *= PPTL;
+  seekToward.y *= PPTL;
 
   // Visualize the planned path
-  drawPlannedPath(shortestPath, cellsPerTile);
+  drawPlannedPath(shortestPath);
 
   // Version for not attempting path-planning
   return {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,6 @@
+import { assert } from '../src/utils/asserts';
+
+
 export const tileTypes = {
   EMPTY_SPACE: 0,
   SQUARE_WALL: 1,
@@ -44,4 +47,12 @@ export const teams = {
   BLUE: 2,
 };
 
-export const PIXELS_PER_TILE = 40;
+// Pixels per tile length
+export const PPTL = 40;
+
+// Cells per tile length
+export const CPTL = 1;
+assert(PPTL % CPTL === 0, 'CPTL does not divide evenly into PPTL');
+
+// Pixels per cell length
+export const PPCL = PPTL / CPTL;

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -12,7 +12,7 @@
  * nonTraversableCellSprites to store the sprites we're going to draw. Then, before drawing the
  * path, we erase any path that was previously drawn.
  */
-import { PIXELS_PER_TILE } from '../constants';
+import { PPCL } from '../constants';
 import { areVisualsOn } from '../utils/interface';
 import { clearSprites, drawSprites } from './utils';
 
@@ -26,21 +26,19 @@ let nonTraversableCellSprites = [];
  * See: http://pixijs.download/dev/docs/PIXI.Graphics.html
  *
  * @param path: an array of cells, each with an x and y coordinate
- * @param cpt: cells per tile, as defined throughout project
  * @param hexColor: the color the sprites should be
  * @param alpha: the opacity of the path drawing, 0-1. 1 = opaque.
  */
-export function createPathSprites(path, cpt, hexColor, alpha) {
+export function createPathSprites(path, hexColor, alpha) {
   const sprites = []; // initialize global object used for storage of PIXI.Graphics
-  const pixelsPerCell = PIXELS_PER_TILE / cpt; // dimensional analysis
   path.forEach(cell => { // create a PIXI.Graphics object for each cell in the path
     // note: all units in pixels
     const rect = new PIXI.Graphics();
     rect.beginFill(hexColor).drawRect(
-      cell.x * pixelsPerCell, // x coordinate
-      cell.y * pixelsPerCell, // y coordinate
-      pixelsPerCell, // width
-      pixelsPerCell, // height
+      cell.x * PPCL, // x coordinate
+      cell.y * PPCL, // y coordinate
+      PPCL, // width
+      PPCL, // height
     ).alpha = alpha;
     sprites.push(rect);
   });
@@ -52,24 +50,21 @@ export function createPathSprites(path, cpt, hexColor, alpha) {
  * object and returns them.
  *
  * @param traversableCells: an grid of cells
- * @param cpt: cells per tile, as defined throughout project
  * @param notTraversableColor: the color the sprites should be
  * @param alpha: the opacity: 0-1. 1 = opaque.
  */
-function createNonTraversableCellSprites(
-  traversableCells, cpt, notTraversableColor, alpha) {
+function createNonTraversableCellSprites(traversableCells, notTraversableColor, alpha) {
   const sprites = [];
-  const pixelsPerCell = PIXELS_PER_TILE / cpt;
   for (let x = 0; x < traversableCells.length; x++) {
     for (let y = 0; y < traversableCells[0].length; y++) {
       // if cell is non traversable and not an empty space
       if (!traversableCells[x][y]) {
         const rect = new PIXI.Graphics();
         rect.beginFill(notTraversableColor).drawRect(
-          x * pixelsPerCell, // x coordinate
-          y * pixelsPerCell, // y coordinate
-          pixelsPerCell, // width
-          pixelsPerCell, // height
+          x * PPCL, // x coordinate
+          y * PPCL, // y coordinate
+          PPCL, // width
+          PPCL, // height
         ).alpha = alpha;
         sprites.push(rect);
       }
@@ -79,24 +74,24 @@ function createNonTraversableCellSprites(
 }
 
 /*
- * Used to draw the bot's planned path. Takes in a reference to a list of cells returned by
- * getShortestPath() in helpers/path.js and the cpt used when calculating shortest path, and draws
- * the corresponding cells in green on the map.
+ * Used to draw the bot's planned path. Takes in a reference to a list of cells
+ * returned by getShortestPath() in helpers/path.js and draws the corresponding
+ * cells in green on the map.
  */
-export function drawPlannedPath(path, cpt, hexColor = 0x00ff00, alpha = 0.25) {
+export function drawPlannedPath(path, hexColor = 0x00ff00, alpha = 0.25) {
   pathSprites = clearSprites(pathSprites); // clear the previous path from the map
   if (areVisualsOn()) {
     // create the PIXI.Graphics objecs we're drawing
-    pathSprites = createPathSprites(path, cpt, hexColor, alpha);
+    pathSprites = createPathSprites(path, hexColor, alpha);
   }
   drawSprites(pathSprites); // put the PIXI.Graphics objects on the map
 }
 
-export function drawNonTraversableCells(traversableCells, cpt, notTraversableColor = 0xff8c00,
+export function drawNonTraversableCells(traversableCells, notTraversableColor = 0xff8c00,
   alpha = 0.4) {
   nonTraversableCellSprites = clearSprites(nonTraversableCellSprites);
   if (areVisualsOn()) {
-    nonTraversableCellSprites = createNonTraversableCellSprites(traversableCells, cpt,
+    nonTraversableCellSprites = createNonTraversableCellSprites(traversableCells,
       notTraversableColor, alpha);
   }
   drawSprites(nonTraversableCellSprites);

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -1,4 +1,4 @@
-import { tileTypes, PPTL, CPTL } from '../constants';
+import { tileTypes, PPTL, CPTL, PPCL } from '../constants';
 import { amBlue, amRed } from './player';
 import { assert, assertGridInBounds } from '../../src/utils/asserts';
 
@@ -183,8 +183,7 @@ export function getTileTraversabilityInCells(tileID) {
         const xDiff = Math.max(Math.abs(i - midCell) - 0.5, 0);
         const yDiff = Math.max(Math.abs(j - midCell) - 0.5, 0);
         const cellDist = Math.sqrt((xDiff * xDiff) + (yDiff * yDiff));
-        const ppc = PPTL / CPTL; // number of pixels per cell length
-        const pixelDist = cellDist * ppc;
+        const pixelDist = cellDist * PPCL;
         if (pixelDist <= getNonTraversableObjectRadius(tileID)) {
           // This cell touches the object, is not traversable
           gridTile[i][j] = 0;

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -217,11 +217,6 @@ export function getMapTraversabilityInCells(map) {
   }
   for (x = 0; x < xl; x++) {
     for (let y = 0; y < yl; y++) {
-      // TODO: Set radius to be correct value for each cell object. Currently
-      // using 29 because it is > 20 * sqrt(2), the furthest distance from the
-      // center of a tile to its corner, in pixels. This guarantees that if the
-      // tile has anything non-tranversable in it (wall, ball, spike, corner
-      // wall), the entire tile is marked as non-traversable
       fillGridWithSubgrid(
         emptyCells,
         getTileTraversabilityInCells(map[x][y]),

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -92,7 +92,7 @@ export function isTraversable(tileID) {
  * Circular nontraversable tiles include: powerups, bombs, active portals,
  *   speed boosts, spikes, and buttons
  */
-export function getNontraversableObjectRadius(tileID) {
+export function getNonTraversableObjectRadius(tileID) {
   switch (tileID) {
     case 'marsball':
       return 39;
@@ -172,7 +172,7 @@ export function fillGridWithSubgrid(bigGrid, smallGrid, x, y) {
  * @param {number} tileID - the ID of the tile that should be split into cells and
  *   parsed for traversability
  */
-export function traversableCellsInTile(tileID) {
+export function getTileTraversabilityInCells(tileID) {
   // Start with all cells being traversable
   const gridTile = init2dArray(CPTL, CPTL, 1);
 
@@ -183,9 +183,9 @@ export function traversableCellsInTile(tileID) {
         const xDiff = Math.max(Math.abs(i - midCell) - 0.5, 0);
         const yDiff = Math.max(Math.abs(j - midCell) - 0.5, 0);
         const cellDist = Math.sqrt((xDiff * xDiff) + (yDiff * yDiff));
-        const ppc = PPTL / CPTL; // number of pixels per cell
+        const ppc = PPTL / CPTL; // number of pixels per cell length
         const pixelDist = cellDist * ppc;
-        if (pixelDist <= getNontraversableObjectRadius(tileID)) {
+        if (pixelDist <= getNonTraversableObjectRadius(tileID)) {
           // This cell touches the object, is not traversable
           gridTile[i][j] = 0;
         }
@@ -207,7 +207,7 @@ export function traversableCellsInTile(tileID) {
  *
  * @param {number} map - 2D array representing the Tagpro map
  */
-export function getTraversableCells(map) {
+export function getMapTraversabilityInCells(map) {
   const xl = map.length;
   const yl = map[0].length;
   const emptyCells = [];
@@ -217,13 +217,14 @@ export function getTraversableCells(map) {
   }
   for (x = 0; x < xl; x++) {
     for (let y = 0; y < yl; y++) {
-      // TODO: Set radius to be correct value for each cell object. Currently using 29 because it
-      // is > 20 * sqrt(2), the furthest distance from the center of a tile to its corner, in
-      // pixels. This guarantees that if the tile has anything non-tranversable in it (wall, ball,
-      // spike, corner wall), the entire tile is marked as non-traversable
+      // TODO: Set radius to be correct value for each cell object. Currently
+      // using 29 because it is > 20 * sqrt(2), the furthest distance from the
+      // center of a tile to its corner, in pixels. This guarantees that if the
+      // tile has anything non-tranversable in it (wall, ball, spike, corner
+      // wall), the entire tile is marked as non-traversable
       fillGridWithSubgrid(
         emptyCells,
-        traversableCellsInTile(map[x][y]),
+        getTileTraversabilityInCells(map[x][y]),
         x * CPTL,
         y * CPTL,
       );

--- a/test/map.spec.js
+++ b/test/map.spec.js
@@ -222,6 +222,7 @@ test('getTileTraversabilityInCells: returns correctly with traversable tile, CPT
     [1],
   ];
   t.same(getTileTraversabilityInCells(tileTypes.YELLOW_FLAG), expected);
+  MapRewireAPI.__ResetDependency__('CPTL');
 
   t.end();
 });
@@ -233,6 +234,8 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
     [0],
   ];
   t.same(getTileTraversabilityInCells(tileTypes.BOMB), expected);
+  MapRewireAPI.__ResetDependency__('CPTL');
+
   t.end();
 });
 
@@ -246,12 +249,14 @@ test('getTileTraversabilityInCells: returns correctly with traversable tile, CPT
     [1, 1, 1, 1],
   ];
   t.same(getTileTraversabilityInCells(tileTypes.YELLOW_FLAG), expected);
+  MapRewireAPI.__ResetDependency__('CPTL');
 
   t.end();
 });
 
 
 test('getTileTraversabilityInCells: returns correctly with nontraversable tile, CPTL=4', t => {
+  MapRewireAPI.__Rewire__('CPTL', 4);
   const expected = [
     [1, 0, 0, 1],
     [0, 0, 0, 0],
@@ -259,12 +264,14 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
     [1, 0, 0, 1],
   ];
   t.same(getTileTraversabilityInCells(tileTypes.SPIKE), expected);
+  MapRewireAPI.__ResetDependency__('CPTL');
 
   t.end();
 });
 
 
 test('getTileTraversabilityInCells: returns correctly with nontraversable tile, CPTL=4', t => {
+  MapRewireAPI.__Rewire__('CPTL', 4);
   const expected = [
     [0, 0, 0, 0],
     [0, 0, 0, 0],
@@ -272,6 +279,7 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
     [0, 0, 0, 0],
   ];
   t.same(getTileTraversabilityInCells(tileTypes.ACTIVE_PORTAL), expected);
+  MapRewireAPI.__ResetDependency__('CPTL');
 
   t.end();
 });
@@ -290,7 +298,9 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
     [1, 1, 1, 1, 1, 1, 1, 1],
   ];
   t.same(getTileTraversabilityInCells(tileTypes.BUTTON), expected);
+  MapRewireAPI.__ResetDependency__('CPTL');
 
+  MapRewireAPI.__Rewire__('CPTL', 8);
   expected = [
     [1, 1, 1, 1, 1, 1, 1, 1],
     [1, 1, 0, 0, 0, 0, 1, 1],
@@ -302,6 +312,7 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
     [1, 1, 1, 1, 1, 1, 1, 1],
   ];
   t.same(getTileTraversabilityInCells(tileTypes.SPIKE), expected);
+  MapRewireAPI.__ResetDependency__('CPTL');
 
   t.end();
 });
@@ -328,7 +339,6 @@ test('getTraversableCells: returns correctly with CPTL=1', t => {
   // initialize current player as blue
   MapRewireAPI.__Rewire__('amBlue', () => true);
   MapRewireAPI.__Rewire__('amRed', () => false);
-
   MapRewireAPI.__Rewire__('CPTL', 1);
   /* eslint-disable no-multi-spaces, array-bracket-spacing */
   const mockMap = [
@@ -344,16 +354,23 @@ test('getTraversableCells: returns correctly with CPTL=1', t => {
     [1, 0, 0],
   ];
   t.same(getMapTraversabilityInCells(mockMap), expected);
+  MapRewireAPI.__ResetDependency__('amBlue');
+  MapRewireAPI.__ResetDependency__('amRed');
+  MapRewireAPI.__ResetDependency__('CPTL');
 
   // initialize current player as red
   MapRewireAPI.__Rewire__('amBlue', () => false);
   MapRewireAPI.__Rewire__('amRed', () => true);
+  MapRewireAPI.__Rewire__('CPTL', 1);
   expected = [
     [0, 1, 1],
     [1, 0, 1],
     [1, 0, 0],
   ];
   t.same(getMapTraversabilityInCells(mockMap), expected);
+  MapRewireAPI.__ResetDependency__('amBlue');
+  MapRewireAPI.__ResetDependency__('amRed');
+  MapRewireAPI.__ResetDependency__('CPTL');
 
   t.end();
 });
@@ -367,6 +384,8 @@ test('getMapTraversabilityInCells: CPTL=2', t => {
   const bluegate = tileTypes.BLUE_GATE;
   const blank = tileTypes.REGULAR_FLOOR;
 
+  MapRewireAPI.__Rewire__('amBlue', () => false);
+  MapRewireAPI.__Rewire__('amRed', () => true);
   MapRewireAPI.__Rewire__('CPTL', 2);
   /* eslint-disable no-multi-spaces, array-bracket-spacing */
   const mockMap = [
@@ -384,12 +403,14 @@ test('getMapTraversabilityInCells: CPTL=2', t => {
     [1, 1, 0, 0, 0, 0],
   ];
   t.same(getMapTraversabilityInCells(mockMap), expected);
+  MapRewireAPI.__ResetDependency__('amBlue');
+  MapRewireAPI.__ResetDependency__('amRed');
+  MapRewireAPI.__ResetDependency__('CPTL');
 
+  MapRewireAPI.__Rewire__('amBlue', () => false);
+  MapRewireAPI.__Rewire__('amRed', () => true);
   MapRewireAPI.__Rewire__('CPTL', 10);
   const smallMap = [[bomb, bluegate]];
-  // For an object with radius 29, there are no traversable cells.
-  // TODO: fix this unit test when we have proper object radii
-  // implemented in getMapTraversabilityInCells
   expected = [
     [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     [1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -402,8 +423,10 @@ test('getMapTraversabilityInCells: CPTL=2', t => {
     [1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
   ];
-
   t.same(getMapTraversabilityInCells(smallMap), expected);
+  MapRewireAPI.__ResetDependency__('amBlue');
+  MapRewireAPI.__ResetDependency__('amRed');
+  MapRewireAPI.__ResetDependency__('CPTL');
 
   t.end();
 });
@@ -415,15 +438,12 @@ test('test multiplyCorrespondingElementsAndSum', t => {
     [4, 5, 6],
     [7, 8, 9],
   ];
-
   const m2 = [
     [9, 8, 7],
     [6, 5, 4],
     [3, 2, 1],
   ];
-
   const expected = 165;
-
   t.is(multiplyCorrespondingElementsAndSum(m1, m2), expected);
 
   t.end();

--- a/test/map.spec.js
+++ b/test/map.spec.js
@@ -2,6 +2,7 @@ import test from 'tape';
 import {
   init2dArray,
   isTraversable,
+  getNonTraversableObjectRadius,
   fillGridWithSubgrid,
   addBufferTo2dArray,
   getSubarrayFrom2dArray,
@@ -14,11 +15,44 @@ import {
 import { tileTypes } from '../src/constants';
 
 
-test('isTraversable: returns correct values for varying inputs', t => {
+test('init2dArray: returns correctly with varying inputs', t => {
+  let width = 5;
+  let height = 3;
+  let defaultVal = 1;
+  let expected = [
+    [1, 1, 1],
+    [1, 1, 1],
+    [1, 1, 1],
+    [1, 1, 1],
+    [1, 1, 1],
+  ];
+  t.same(init2dArray(width, height, defaultVal), expected);
+
+  width = 3;
+  height = 3;
+  defaultVal = 55;
+  expected = [
+    [55, 55, 55],
+    [55, 55, 55],
+    [55, 55, 55],
+  ];
+  t.same(init2dArray(width, height, defaultVal), expected);
+
+  t.end();
+});
+
+
+test('isTraversable: correctly returns true for varying inputs', t => {
   t.true(isTraversable(2)); // Regular floor
   t.true(isTraversable(3.1)); // taken red flag
   t.true(isTraversable(9)); // inactive gate
   t.true(isTraversable(17)); // red endzone
+
+  t.end();
+});
+
+
+test('isTraversable: correctly returns false for varying inputs', t => {
   t.false(isTraversable(0)); // Blank space
   t.false(isTraversable(1)); // square wall
   t.false(isTraversable(7)); // spike
@@ -32,11 +66,29 @@ test('isTraversable: throws errors for invalid inputs', t => {
   t.throws(() => { isTraversable(-1); });
   t.throws(() => { isTraversable('potato'); });
   t.throws(() => { isTraversable(undefined); });
+
   t.end();
 });
 
 
-test('fillGridWithSubgrid: fills larger grids correctly', t => {
+test('getNonTraversableObjectRadius: correctly returns for varying inputs', t => {
+  t.is(getNonTraversableObjectRadius(tileTypes.SPIKE), 14);
+  t.is(getNonTraversableObjectRadius(tileTypes.BUTTON), 8);
+
+  t.end();
+});
+
+
+test('getNonTraversableObjectRadius: throws errors for invalid inputs', t => {
+  t.throws(() => { getNonTraversableObjectRadius(tileTypes.YELLOW_FLAG); });
+  t.throws(() => { getNonTraversableObjectRadius('banana'); });
+  t.throws(() => { getNonTraversableObjectRadius(undefined); });
+
+  t.end();
+});
+
+
+test('fillGridWithSubgrid: correctly fills larger grids', t => {
   let grid = [
     [0, 0, 0],
     [0, 0, 0],
@@ -220,6 +272,7 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
     [0, 0, 0, 0],
   ];
   t.same(getTileTraversabilityInCells(tileTypes.ACTIVE_PORTAL), expected);
+
   t.end();
 });
 
@@ -351,33 +404,6 @@ test('getMapTraversabilityInCells: CPTL=2', t => {
   ];
 
   t.same(getMapTraversabilityInCells(smallMap), expected);
-
-  t.end();
-});
-
-
-test('test init2dArray', t => {
-  let width = 5;
-  let height = 3;
-  let defaultVal = 1;
-  let expected = [
-    [1, 1, 1],
-    [1, 1, 1],
-    [1, 1, 1],
-    [1, 1, 1],
-    [1, 1, 1],
-  ];
-  t.same(init2dArray(width, height, defaultVal), expected);
-
-  width = 3;
-  height = 3;
-  defaultVal = 55;
-  expected = [
-    [55, 55, 55],
-    [55, 55, 55],
-    [55, 55, 55],
-  ];
-  t.same(init2dArray(width, height, defaultVal), expected);
 
   t.end();
 });

--- a/test/map.spec.js
+++ b/test/map.spec.js
@@ -218,11 +218,13 @@ test('getSubarrayFrom2dArray: returns correct subarray for varying inputs', t =>
 
 test('getTileTraversabilityInCells: returns correctly with traversable tile, CPTL=1', t => {
   MapRewireAPI.__Rewire__('CPTL', 1);
+  MapRewireAPI.__Rewire__('PPCL', 40);
   const expected = [
     [1],
   ];
   t.same(getTileTraversabilityInCells(tileTypes.YELLOW_FLAG), expected);
   MapRewireAPI.__ResetDependency__('CPTL');
+  MapRewireAPI.__ResetDependency__('PPCL');
 
   t.end();
 });
@@ -230,11 +232,13 @@ test('getTileTraversabilityInCells: returns correctly with traversable tile, CPT
 
 test('getTileTraversabilityInCells: returns correctly with nontraversable tile, CPTL=1', t => {
   MapRewireAPI.__Rewire__('CPTL', 1);
+  MapRewireAPI.__Rewire__('PPCL', 40);
   const expected = [
     [0],
   ];
   t.same(getTileTraversabilityInCells(tileTypes.BOMB), expected);
   MapRewireAPI.__ResetDependency__('CPTL');
+  MapRewireAPI.__ResetDependency__('PPCL');
 
   t.end();
 });
@@ -242,6 +246,7 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
 
 test('getTileTraversabilityInCells: returns correctly with traversable tile, CPTL=4', t => {
   MapRewireAPI.__Rewire__('CPTL', 4);
+  MapRewireAPI.__Rewire__('PPCL', 10);
   const expected = [
     [1, 1, 1, 1],
     [1, 1, 1, 1],
@@ -250,6 +255,7 @@ test('getTileTraversabilityInCells: returns correctly with traversable tile, CPT
   ];
   t.same(getTileTraversabilityInCells(tileTypes.YELLOW_FLAG), expected);
   MapRewireAPI.__ResetDependency__('CPTL');
+  MapRewireAPI.__ResetDependency__('PPCL');
 
   t.end();
 });
@@ -257,6 +263,7 @@ test('getTileTraversabilityInCells: returns correctly with traversable tile, CPT
 
 test('getTileTraversabilityInCells: returns correctly with nontraversable tile, CPTL=4', t => {
   MapRewireAPI.__Rewire__('CPTL', 4);
+  MapRewireAPI.__Rewire__('PPCL', 10);
   const expected = [
     [1, 0, 0, 1],
     [0, 0, 0, 0],
@@ -265,6 +272,7 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
   ];
   t.same(getTileTraversabilityInCells(tileTypes.SPIKE), expected);
   MapRewireAPI.__ResetDependency__('CPTL');
+  MapRewireAPI.__ResetDependency__('PPCL');
 
   t.end();
 });
@@ -272,6 +280,7 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
 
 test('getTileTraversabilityInCells: returns correctly with nontraversable tile, CPTL=4', t => {
   MapRewireAPI.__Rewire__('CPTL', 4);
+  MapRewireAPI.__Rewire__('PPCL', 10);
   const expected = [
     [0, 0, 0, 0],
     [0, 0, 0, 0],
@@ -280,6 +289,7 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
   ];
   t.same(getTileTraversabilityInCells(tileTypes.ACTIVE_PORTAL), expected);
   MapRewireAPI.__ResetDependency__('CPTL');
+  MapRewireAPI.__ResetDependency__('PPCL');
 
   t.end();
 });
@@ -287,6 +297,7 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
 
 test('getTileTraversabilityInCells: returns correctly with nontraversable tile, CPTL=8', t => {
   MapRewireAPI.__Rewire__('CPTL', 8);
+  MapRewireAPI.__Rewire__('PPCL', 5);
   let expected = [
     [1, 1, 1, 1, 1, 1, 1, 1],
     [1, 1, 1, 1, 1, 1, 1, 1],
@@ -299,8 +310,10 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
   ];
   t.same(getTileTraversabilityInCells(tileTypes.BUTTON), expected);
   MapRewireAPI.__ResetDependency__('CPTL');
+  MapRewireAPI.__ResetDependency__('PPCL');
 
   MapRewireAPI.__Rewire__('CPTL', 8);
+  MapRewireAPI.__Rewire__('PPCL', 5);
   expected = [
     [1, 1, 1, 1, 1, 1, 1, 1],
     [1, 1, 0, 0, 0, 0, 1, 1],
@@ -313,6 +326,7 @@ test('getTileTraversabilityInCells: returns correctly with nontraversable tile, 
   ];
   t.same(getTileTraversabilityInCells(tileTypes.SPIKE), expected);
   MapRewireAPI.__ResetDependency__('CPTL');
+  MapRewireAPI.__ResetDependency__('PPCL');
 
   t.end();
 });
@@ -328,7 +342,7 @@ test('getTileTraversabilityInCells: throws errors for invalid inputs', t => {
 });
 
 
-test('getTraversableCells: returns correctly with CPTL=1', t => {
+test('getMapTraversabilityInCells: returns correctly with CPTL=1', t => {
   // create a dummy map from bombs, spikes, gates, and regular tiles
   const bomb = tileTypes.BOMB;
   const spike = tileTypes.SPIKE;
@@ -410,6 +424,7 @@ test('getMapTraversabilityInCells: CPTL=2', t => {
   MapRewireAPI.__Rewire__('amBlue', () => false);
   MapRewireAPI.__Rewire__('amRed', () => true);
   MapRewireAPI.__Rewire__('CPTL', 10);
+  MapRewireAPI.__Rewire__('PPCL', 4);
   const smallMap = [[bomb, bluegate]];
   expected = [
     [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -427,6 +442,7 @@ test('getMapTraversabilityInCells: CPTL=2', t => {
   MapRewireAPI.__ResetDependency__('amBlue');
   MapRewireAPI.__ResetDependency__('amRed');
   MapRewireAPI.__ResetDependency__('CPTL');
+  MapRewireAPI.__ResetDependency__('PPCL');
 
   t.end();
 });

--- a/test/map.spec.js
+++ b/test/map.spec.js
@@ -1,12 +1,12 @@
 import test from 'tape';
 import {
+  init2dArray,
   isTraversable,
   fillGridWithSubgrid,
   addBufferTo2dArray,
   getSubarrayFrom2dArray,
-  traversableCellsInTile,
-  getTraversableCells,
-  init2dArray,
+  getTileTraversabilityInCells,
+  getMapTraversabilityInCells,
   multiplyCorrespondingElementsAndSum,
   convolve,
   __RewireAPI__ as MapRewireAPI,
@@ -164,28 +164,28 @@ test('getSubarrayFrom2dArray: returns correct subarray for varying inputs', t =>
 });
 
 
-test('traversableCellsInTile: returns correctly with traversable tile, CPTL=1', t => {
+test('getTileTraversabilityInCells: returns correctly with traversable tile, CPTL=1', t => {
   MapRewireAPI.__Rewire__('CPTL', 1);
   const expected = [
     [1],
   ];
-  t.same(traversableCellsInTile(tileTypes.YELLOW_FLAG), expected);
+  t.same(getTileTraversabilityInCells(tileTypes.YELLOW_FLAG), expected);
 
   t.end();
 });
 
 
-test('traversableCellsInTile: returns correctly with nontraversable tile, CPTL=1', t => {
+test('getTileTraversabilityInCells: returns correctly with nontraversable tile, CPTL=1', t => {
   MapRewireAPI.__Rewire__('CPTL', 1);
   const expected = [
     [0],
   ];
-  t.same(traversableCellsInTile(tileTypes.BOMB), expected);
+  t.same(getTileTraversabilityInCells(tileTypes.BOMB), expected);
   t.end();
 });
 
 
-test('traversableCellsInTile: returns correctly with traversable tile, CPTL=4', t => {
+test('getTileTraversabilityInCells: returns correctly with traversable tile, CPTL=4', t => {
   MapRewireAPI.__Rewire__('CPTL', 4);
   const expected = [
     [1, 1, 1, 1],
@@ -193,38 +193,38 @@ test('traversableCellsInTile: returns correctly with traversable tile, CPTL=4', 
     [1, 1, 1, 1],
     [1, 1, 1, 1],
   ];
-  t.same(traversableCellsInTile(tileTypes.YELLOW_FLAG), expected);
+  t.same(getTileTraversabilityInCells(tileTypes.YELLOW_FLAG), expected);
 
   t.end();
 });
 
 
-test('traversableCellsInTile: returns correctly with nontraversable tile, CPTL=4', t => {
+test('getTileTraversabilityInCells: returns correctly with nontraversable tile, CPTL=4', t => {
   const expected = [
     [1, 0, 0, 1],
     [0, 0, 0, 0],
     [0, 0, 0, 0],
     [1, 0, 0, 1],
   ];
-  t.same(traversableCellsInTile(tileTypes.SPIKE), expected);
+  t.same(getTileTraversabilityInCells(tileTypes.SPIKE), expected);
 
   t.end();
 });
 
 
-test('traversableCellsInTile: returns correctly with nontraversable tile, CPTL=4', t => {
+test('getTileTraversabilityInCells: returns correctly with nontraversable tile, CPTL=4', t => {
   const expected = [
     [0, 0, 0, 0],
     [0, 0, 0, 0],
     [0, 0, 0, 0],
     [0, 0, 0, 0],
   ];
-  t.same(traversableCellsInTile(tileTypes.ACTIVE_PORTAL), expected);
+  t.same(getTileTraversabilityInCells(tileTypes.ACTIVE_PORTAL), expected);
   t.end();
 });
 
 
-test('traversableCellsInTile: returns correctly with nontraversable tile, CPTL=8', t => {
+test('getTileTraversabilityInCells: returns correctly with nontraversable tile, CPTL=8', t => {
   MapRewireAPI.__Rewire__('CPTL', 8);
   let expected = [
     [1, 1, 1, 1, 1, 1, 1, 1],
@@ -236,7 +236,7 @@ test('traversableCellsInTile: returns correctly with nontraversable tile, CPTL=8
     [1, 1, 1, 1, 1, 1, 1, 1],
     [1, 1, 1, 1, 1, 1, 1, 1],
   ];
-  t.same(traversableCellsInTile(tileTypes.BUTTON), expected);
+  t.same(getTileTraversabilityInCells(tileTypes.BUTTON), expected);
 
   expected = [
     [1, 1, 1, 1, 1, 1, 1, 1],
@@ -248,17 +248,17 @@ test('traversableCellsInTile: returns correctly with nontraversable tile, CPTL=8
     [1, 1, 0, 0, 0, 0, 1, 1],
     [1, 1, 1, 1, 1, 1, 1, 1],
   ];
-  t.same(traversableCellsInTile(tileTypes.SPIKE), expected);
+  t.same(getTileTraversabilityInCells(tileTypes.SPIKE), expected);
 
   t.end();
 });
 
 
-test('traversableCellsInTile: throws errors for invalid inputs', t => {
-  t.throws(() => { traversableCellsInTile(false); });
-  t.throws(() => { traversableCellsInTile(1.23); });
-  t.throws(() => { traversableCellsInTile(undefined); });
-  t.throws(() => { traversableCellsInTile('apple'); });
+test('getTileTraversabilityInCells: throws errors for invalid inputs', t => {
+  t.throws(() => { getTileTraversabilityInCells(false); });
+  t.throws(() => { getTileTraversabilityInCells(1.23); });
+  t.throws(() => { getTileTraversabilityInCells(undefined); });
+  t.throws(() => { getTileTraversabilityInCells('apple'); });
 
   t.end();
 });
@@ -290,7 +290,7 @@ test('getTraversableCells: returns correctly with CPTL=1', t => {
     [0, 1, 1],
     [1, 0, 0],
   ];
-  t.same(getTraversableCells(mockMap), expected);
+  t.same(getMapTraversabilityInCells(mockMap), expected);
 
   // initialize current player as red
   MapRewireAPI.__Rewire__('amBlue', () => false);
@@ -300,13 +300,13 @@ test('getTraversableCells: returns correctly with CPTL=1', t => {
     [1, 0, 1],
     [1, 0, 0],
   ];
-  t.same(getTraversableCells(mockMap), expected);
+  t.same(getMapTraversabilityInCells(mockMap), expected);
 
   t.end();
 });
 
 
-test('getTraversableCells: CPTL=2', t => {
+test('getMapTraversabilityInCells: CPTL=2', t => {
   // create a dummy map from bombs, spikes, gates, and regular tiles
   const bomb = tileTypes.BOMB;
   const spike = tileTypes.SPIKE;
@@ -330,13 +330,13 @@ test('getTraversableCells: CPTL=2', t => {
     [1, 1, 0, 0, 0, 0],
     [1, 1, 0, 0, 0, 0],
   ];
-  t.same(getTraversableCells(mockMap), expected);
+  t.same(getMapTraversabilityInCells(mockMap), expected);
 
   MapRewireAPI.__Rewire__('CPTL', 10);
   const smallMap = [[bomb, bluegate]];
   // For an object with radius 29, there are no traversable cells.
   // TODO: fix this unit test when we have proper object radii
-  // implemented in getTraversableCells
+  // implemented in getMapTraversabilityInCells
   expected = [
     [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     [1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -350,7 +350,7 @@ test('getTraversableCells: CPTL=2', t => {
     [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
   ];
 
-  t.same(getTraversableCells(smallMap), expected);
+  t.same(getMapTraversabilityInCells(smallMap), expected);
 
   t.end();
 });

--- a/test/visualizePath.spec.js
+++ b/test/visualizePath.spec.js
@@ -1,10 +1,14 @@
 import sinon from 'sinon';
 import test from 'tape';
-
-import { drawPlannedPath, drawNonTraversableCells, __RewireAPI__ as DrawingRewireAPI } from '../src/draw/drawings';
+import {
+  drawPlannedPath,
+  drawNonTraversableCells,
+  __RewireAPI__ as DrawingRewireAPI,
+} from '../src/draw/drawings';
 import { clearSprites, drawSprites } from '../src/draw/utils';
 
-test('clearSprites() calls removeChild for each sprite', t => {
+
+test('clearSprites: calls removeChild for each sprite', t => {
   const mockRemoveChild = sinon.spy();
   const pathSprites = [1, 2, 3];
   global.tagpro = {
@@ -17,7 +21,8 @@ test('clearSprites() calls removeChild for each sprite', t => {
   t.end();
 });
 
-test('clearSprites() returns an empty array', t => {
+
+test('clearSprites: returns an empty array', t => {
   const mockRemoveChild = sinon.spy();
   let pathSprites = [1, 2, 3];
   global.tagpro = {
@@ -30,7 +35,8 @@ test('clearSprites() returns an empty array', t => {
   t.end();
 });
 
-test('clearSprites() calls addChild for each sprite', t => {
+
+test('clearSprites: calls addChild for each sprite', t => {
   const mockAddChild = sinon.spy();
   const pathSprites = [1, 2, 3];
   global.tagpro = {
@@ -43,7 +49,8 @@ test('clearSprites() calls addChild for each sprite', t => {
   t.end();
 });
 
-test('drawPlannedPath() calls the right functions with areVisualsOn false', t => {
+
+test('drawPlannedPath: calls the right functions with areVisualsOn=false', t => {
   const mockClearSprites = sinon.spy();
   const mockCreatePathSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
@@ -54,11 +61,11 @@ test('drawPlannedPath() calls the right functions with areVisualsOn false', t =>
   DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
   DrawingRewireAPI.__Rewire__('areVisualsOn', mockVisual);
 
-  drawPlannedPath('path', 'cpt', 'hexColor', 'alpha');
+  drawPlannedPath('path', 'hexColor', 'alpha');
 
   t.true(mockVisual.calledOnce);
   t.true(mockClearSprites.calledOnce);
-  t.true(mockCreatePathSprites.calledWith('path', 'cpt', 'hexColor', 'alpha'));
+  t.true(mockCreatePathSprites.calledWith('path', 'hexColor', 'alpha'));
   t.true(mockDrawSprites.calledOnce);
 
   DrawingRewireAPI.__ResetDependency__('clearSprites');
@@ -68,7 +75,8 @@ test('drawPlannedPath() calls the right functions with areVisualsOn false', t =>
   t.end();
 });
 
-test('drawPlannedPath() calls the right functions with areVisualsOn false', t => {
+
+test('drawPlannedPath: calls the right functions with areVisualsOn=false', t => {
   const mockClearSprites = sinon.spy();
   const mockCreatePathSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
@@ -79,7 +87,7 @@ test('drawPlannedPath() calls the right functions with areVisualsOn false', t =>
   DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
   DrawingRewireAPI.__Rewire__('areVisualsOn', mockVisual);
 
-  drawPlannedPath('path', 'cpt', 'hexColor', 'alpha');
+  drawPlannedPath('path', 'hexColor', 'alpha');
 
   t.true(mockVisual.calledOnce);
   t.true(mockClearSprites.calledOnce);
@@ -93,7 +101,8 @@ test('drawPlannedPath() calls the right functions with areVisualsOn false', t =>
   t.end();
 });
 
-test('drawNonTraversableCells() calls the right functions with areVisualsOn true', t => {
+
+test('drawNonTraversableCells: calls the right functions with areVisualsOn=true', t => {
   const mockClearSprites = sinon.spy();
   const mockCreateNonTraversableCellSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
@@ -105,12 +114,12 @@ test('drawNonTraversableCells() calls the right functions with areVisualsOn true
   DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
   DrawingRewireAPI.__Rewire__('areVisualsOn', mockVisual);
 
-  drawNonTraversableCells('traversableCells', 'cpt', 'hexColor', 'alpha');
+  drawNonTraversableCells('traversableCells', 'hexColor', 'alpha');
 
   t.true(mockVisual.calledOnce);
   t.true(mockClearSprites.calledOnce);
   t.true(mockCreateNonTraversableCellSprites.calledWith(
-    'traversableCells', 'cpt', 'hexColor', 'alpha'));
+    'traversableCells', 'hexColor', 'alpha'));
   t.true(mockDrawSprites.calledOnce);
 
   DrawingRewireAPI.__ResetDependency__('clearSprites');
@@ -120,7 +129,8 @@ test('drawNonTraversableCells() calls the right functions with areVisualsOn true
   t.end();
 });
 
-test('drawNonTraversableCells() calls the right functions with areVisualsOn false', t => {
+
+test('drawNonTraversableCells: calls the right functions with areVisualsOn=false', t => {
   const mockClearSprites = sinon.spy();
   const mockCreateNonTraversableCellSprites = sinon.spy();
   const mockDrawSprites = sinon.spy();
@@ -132,7 +142,7 @@ test('drawNonTraversableCells() calls the right functions with areVisualsOn fals
   DrawingRewireAPI.__Rewire__('drawSprites', mockDrawSprites);
   DrawingRewireAPI.__Rewire__('areVisualsOn', mockVisual);
 
-  drawNonTraversableCells('traversableCells', 'cpt', 'hexColor', 'alpha');
+  drawNonTraversableCells('traversableCells', 'hexColor', 'alpha');
 
   t.true(mockVisual.calledOnce);
   t.true(mockClearSprites.calledOnce);


### PR DESCRIPTION
Closes #91 Closes #47 

This PR does two things:
- Renames `cpt` to `CPTL`, makes it a global constant, and no longer passes it into the `traversable` functions.
- Creates an initial `getNontraversableObjectRadius` function to use during path planning

I somehow got it in my head that these two very distinct issues were a single story, so I addressed them in a single commit... I wish I hadn't done that. So, yeah.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chauncy-crib/tagprobot/96)
<!-- Reviewable:end -->
