### PR TITLE
123: adding reviewable script

### DIFF
--- a/reviewable.js
+++ b/reviewable.js
@@ -1,3 +1,6 @@
+// These variables are provided by the reviewable environment.
+// For debugging, I imported these functions and created a sample json PR using the info
+// in: https://github.com/Reviewable/Reviewable/wiki/FAQ
 // import _ from 'lodash';
 // import review from './sample_pr.json';
 

--- a/reviewable.js
+++ b/reviewable.js
@@ -1,5 +1,5 @@
 // These variables are provided by the reviewable environment.
-// For debugging, I imported these functions and created a sample json PR using the info
+// For debugging, we import these functions and created a sample json PR using the info
 // in: https://github.com/Reviewable/Reviewable/wiki/FAQ
 // import _ from 'lodash';
 // import review from './sample_pr.json';

--- a/reviewable.js
+++ b/reviewable.js
@@ -1,0 +1,100 @@
+// import _ from 'lodash';
+// import review from './sample_pr.json';
+
+const numReviewersRequired = 2;
+
+const files = {};
+// TODO: load chauncy members dynamically
+const chauncy = ['davidabrahams', 'billmwong', 'shanek21', 'altodyte'];
+
+_.each(review.files, file => {
+  const reviewInfo = {};
+  // reviewers are all people who submitted reviews on the last file revision , other than
+  // the PR author
+  const reviewers = _(_.last(file.revisions).reviewers)
+    .map('username')
+    .without(review.pullRequest.author.username)
+    .value();
+  const neededReviewers = [];
+  if (reviewers.length < numReviewersRequired) {
+    // place all non-author chauncy members who haven't reviewed the file and add them
+    // to neededReviewers
+    _.each(_(chauncy)
+      .without(review.pullRequest.author.username)
+      .filter(c => !_.includes(reviewers, c))
+      .value(), r => neededReviewers.push(r));
+  }
+  reviewInfo.neededReviewers = neededReviewers;
+  reviewInfo.numReviewsLeft = Math.max(0, numReviewersRequired - reviewers.length);
+  reviewInfo.revision = _.last(file.revisions).key;
+  files[file.path] = reviewInfo;
+});
+
+// map from chauncy member to the number of discussions they must resolve
+const discussions = {};
+_.each(chauncy, c => { discussions[c] = 0; });
+_.each(_(review.discussions)
+  .map('participants')
+  .flatten()
+  .filter({ resolved: false })
+  .value(),
+d => { discussions[d.username] += 1; });
+
+const unresolvedDiscussions = _.pick(discussions, o => o > 0);
+const completed = _(files)
+  // no files have reviews remaining
+  .values()
+  .map('numReviewsLeft')
+  .map(c => c === 0)
+  .every()
+  &&
+  // no discussions are unresolved
+  !_(discussions)
+    .values()
+    .some();
+
+const shortReasons = [];
+for (let i = 1; i <= numReviewersRequired; i++) {
+  const numFiles = _(files).keys().filter(f => files[f].numReviewsLeft === i).value().length;
+  if (numFiles) {
+    // N file(s) need(s) M review(s)
+    shortReasons.push(numFiles.toString() + ' file' + (numFiles > 1 ? 's' : '') + ' need' +
+      (numFiles === 1 ? 's ' : ' ') + i.toString() + ' review' + (i > 1 ? 's' : ''));
+  }
+}
+if (!_.isEmpty(unresolvedDiscussions)) {
+  const pendingChauncies = _.keys(unresolvedDiscussions);
+  shortReasons.push(pendingChauncies.join(', ') + ' must resolve discussions');
+}
+
+const longReasons = [];
+
+_.each(chauncy, c => {
+  const filesToReview = _(files)
+  .keys()
+  // files where this chauncy needs to review it
+  .filter(f => _.includes(files[f].neededReviewers, c))
+  // and there are reviews required
+  .filter(f => files[f].numReviewsLeft)
+  .value();
+  if (filesToReview.length) {
+    longReasons.push(c + ' must review ' + filesToReview.length + ' file' + (filesToReview.length > 1 ? 's' : ''));
+  }
+});
+
+_.each(_.keys(discussions),
+  c => {
+    if (discussions[c])
+    longReasons.push(c + ' must resolve ' + discussions[c] + ' discussion' + (discussions[c] > 1 ? 's' : ''));
+  }
+);
+
+const reviewableStatus = {
+  completed,
+  description: longReasons.join(', '),
+  shortDescription: shortReasons.join(', '),
+};
+
+// console.log(reviewableStatus);
+
+return reviewableStatus;

--- a/reviewable.js
+++ b/reviewable.js
@@ -98,6 +98,4 @@ const reviewableStatus = {
   shortDescription: shortReasons.join(', '),
 };
 
-// console.log(reviewableStatus);
-
 return reviewableStatus;


### PR DESCRIPTION
I set up a custom configuration on reviewable that matches our workflow. It makes sure every discussion is resolved, and that every file has 2 reviews. It also gives a much more descriptive error message for who needs to do what:

![screenshot from 2017-08-14 00-35-17](https://user-images.githubusercontent.com/8933701/29262306-c9833586-8088-11e7-9ea4-b6a62512ebda.png)

If you haven't reviewed a file, but it already has 2 reviews, this won't contribute toward your "need to review" count.

This is already integrated on reviewable, but I figured we should version control it. If you want info on how the `review` object is set up, read [this](https://github.com/Reviewable/Reviewable/wiki/FAQ)

Closes #123 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chauncy-crib/tagprobot/130)
<!-- Reviewable:end -->
