### PR TITLE
132: missing properties

### DIFF
--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -1,7 +1,7 @@
 import isEmpty from 'lodash/isEmpty';
 import { PPTL, CPTL, PPCL } from '../constants';
 import { assert, assertGridInBounds } from '../utils/asserts';
-import { getTileProperty, tileIsType } from '../tiles';
+import { getTileProperty, tileHasProperty, tileIsType } from '../tiles';
 
 const mapTraversabilityCells = [];
 // A list of x, y pairs, which are the locations in the map that might change
@@ -64,7 +64,7 @@ export function getTileTraversabilityInCells(tileID) {
     const midCell = (CPTL - 1.0) / 2.0;
     for (let i = 0; i < CPTL; i++) {
       for (let j = 0; j < CPTL; j++) {
-        if (getTileProperty(tileID, 'radius')) {
+        if (tileHasProperty(tileID, 'radius')) {
           const xDiff = Math.max(Math.abs(i - midCell) - 0.5, 0);
           const yDiff = Math.max(Math.abs(j - midCell) - 0.5, 0);
           const cellDist = Math.sqrt((xDiff * xDiff) + (yDiff * yDiff));

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -73,9 +73,7 @@ export function computeTileInfo() {
  * @return - the property for the input tile
  */
 export function getTileProperty(tileID, property) {
-  const tileIDString = String(tileID);
-  assert(has(tileNames, tileIDString), `Unknown tileID: ${tileID}`);
-  const tileName = tileNames[tileID];
+  assert(tileHasProperty(tileID, property), `Unknown property for tile: ${tileName}`);
   return tileInfo[tileName][property];
 }
 

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -5,6 +5,7 @@ import has from 'lodash/has';
 import { assert } from './utils/asserts';
 import { amBlue, amRed } from './helpers/player';
 
+
 const tileInfo = {};
 const tileNames = {};
 
@@ -67,16 +68,6 @@ export function computeTileInfo() {
   });
 }
 
-/*
- * @param {number} tileID - the ID of the tile whose property we want
- * @param {String} property - the name of a property stored in tileInfo
- * @return - the property for the input tile
- */
-export function getTileProperty(tileID, property) {
-  assert(tileHasProperty(tileID, property), `Unknown property for tile: ${tileName}`);
-  return tileInfo[tileName][property];
-}
-
 
 /*
  * @param {number} tileID - the ID of the tile
@@ -88,6 +79,18 @@ export function tileHasProperty(tileID, property) {
   assert(has(tileNames, tileIDString), `Unknown tileID: ${tileID}`);
   const tileName = tileNames[tileID];
   return has(tileInfo[tileName], property);
+}
+
+
+/*
+ * @param {number} tileID - the ID of the tile whose property we want
+ * @param {String} property - the name of a property stored in tileInfo
+ * @return - the property for the input tile
+ */
+export function getTileProperty(tileID, property) {
+  assert(tileHasProperty(tileID, property), `Unknown property for tile: ${tileID}, ${property}`);
+  const tileName = tileNames[tileID];
+  return tileInfo[tileName][property];
 }
 
 

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -81,6 +81,19 @@ export function getTileProperty(tileID, property) {
 
 
 /*
+ * @param {number} tileID - the ID of the tile
+ * @param {String} property - the name of a property
+ * @return - if the corresponding tile has a value for this property
+ */
+export function tileHasProperty(tileID, property) {
+  const tileIDString = String(tileID);
+  assert(has(tileNames, tileIDString), `Unknown tileID: ${tileID}`);
+  const tileName = tileNames[tileID];
+  return has(tileInfo[tileName], property);
+}
+
+
+/*
  * @param {String} name - the name of a tile
  * @return - the id for the input tile name
  */

--- a/test/tiles.spec.js
+++ b/test/tiles.spec.js
@@ -9,6 +9,7 @@ import {
   computeTileInfo,
   getTileProperty,
   tileIsType,
+  tileHasProperty,
   __RewireAPI__ as TileRewireAPI,
 } from '../src/tiles';
 
@@ -113,6 +114,28 @@ test('getTileProperty: throws error given tileIds that don\'t exist', t => {
   t.throws(() => { getTileProperty(-1, 'traversable'); });
   t.throws(() => { getTileProperty('potato', 'traversable'); });
   t.throws(() => { getTileProperty(undefined, 'traversable'); });
+  teardownTiles();
+
+  t.end();
+});
+
+
+test('getTileProperty: throws error given properties that don\'t exist', t => {
+  setupTiles(true);
+  t.throws(() => { getTileProperty(5, 'potato'); });
+  t.throws(() => { getTileProperty(4.1, 'radius'); });
+  teardownTiles();
+
+  t.end();
+});
+
+
+test('tileHasProperty: checks if a tile has a property', t => {
+  setupTiles(true);
+  t.true(tileHasProperty(4.1, 'permanent'));
+  t.true(tileHasProperty(6.1, 'radius'));
+  t.false(tileHasProperty(0, 'radius'));
+  t.false(tileHasProperty(1, 'radius'));
   teardownTiles();
 
   t.end();


### PR DESCRIPTION
getTileProperty throws an error if you provide a property it doesn't have. Use tileHasProperty instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chauncy-crib/tagprobot/137)
<!-- Reviewable:end -->
