### PR TITLE
131: update tile api

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,9 +1,8 @@
 import { PPCL } from './constants';
-import { getTileId } from './tiles';
 import { getMapTraversabilityInCells } from './helpers/map';
 import { findTile, findEnemyFC } from './helpers/finders';
 import { myTeamHasFlag, enemyTeamHasFlag } from './helpers/gameState';
-import { getMe, getAllyEndzoneTileId, getEnemyEndzoneTileId } from './helpers/player';
+import { getMe, getAllyEndzoneTileName, getEnemyEndzoneTileName } from './helpers/player';
 import { getShortestPath, getTarget } from './helpers/path';
 import { isAutonomousMode, isVisualMode, move } from './utils/interface';
 import { updatePath } from './draw/drawings';
@@ -26,7 +25,7 @@ function getGoalPos() {
 
   // If the bot has the flag, go to the endzone
   if (me.flag) {
-    goal = findTile(getAllyEndzoneTileId());
+    goal = findTile(getAllyEndzoneTileName());
     console.log('I have the flag. Seeking endzone!');
   } else {
     const enemyFC = findEnemyFC();
@@ -36,13 +35,13 @@ function getGoalPos() {
       goal.y = enemyFC.y + enemyFC.vy;
       console.log('I see an enemy with the flag. Chasing!');
     } else if (enemyTeamHasFlag()) {
-      goal = findTile(getEnemyEndzoneTileId());
+      goal = findTile(getEnemyEndzoneTileName());
       console.log('Enemy has the flag. Headed towards the Enemy Endzone.');
     } else if (myTeamHasFlag()) {
-      goal = findTile(getAllyEndzoneTileId());
+      goal = findTile(getAllyEndzoneTileName());
       console.log('We have the flag. Headed towards our Endzone.');
     } else {
-      goal = findTile([getTileId('YELLOW_FLAG'), getTileId('YELLOW_FLAG_TAKEN')]);
+      goal = findTile(['YELLOW_FLAG', 'YELLOW_FLAG_TAKEN']);
       console.log("I don't know what to do. Going to central flag station!");
     }
   }

--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -123,11 +123,11 @@ export function generatePermanentNTSprites(x, y, cellTraversabilities) {
  * it to the correct size as specified by the comment at the top of this file
  * Runtime: O(CPTL^2), O(1) if visualizations off
  *
- * @param {number} x - x location, in tiles
- * @param {number} y - y location, in tiles
+ * @param {number} xt - x location, in tiles
+ * @param {number} yt - y location, in tiles
  * @param {Array} cellTraversabilities - the cell-traversabilities of the tagpro map.
  */
-export function updateNTSprites(x, y, cellTraversabilities) {
+export function updateNTSprites(xt, yt, cellTraversabilities) {
   if (!isVisualMode()) {
     return;
   }
@@ -138,8 +138,8 @@ export function updateNTSprites(x, y, cellTraversabilities) {
       null,
     );
   }
-  for (let i = x * CPTL; i < (x + 1) * CPTL; i++) {
-    for (let j = y * CPTL; j < (y + 1) * CPTL; j++) {
+  for (let i = xt * CPTL; i < (xt + 1) * CPTL; i++) {
+    for (let j = yt * CPTL; j < (yt + 1) * CPTL; j++) {
       // if we don't have a sprite already there and there should be one,
       // draw it
       if (_.isNull(tempNTSprites[i][j]) && !cellTraversabilities[i][j]) {

--- a/src/helpers/finders.js
+++ b/src/helpers/finders.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import { tileIsType } from '../tiles';
+import { tileHasName } from '../tiles';
 import { isOnMyTeam } from './player';
 import { PPTL } from '../constants';
 import { assert } from '../utils/asserts';
@@ -26,7 +26,7 @@ export function findTile(tileNames) {
   for (let xt = 0, xl = tagpro.map.length; xt < xl; xt++) {
     for (let yt = 0, yl = tagpro.map[0].length; yt < yl; yt++) {
       for (let i = 0; i < tileNameArray.length; i++) {
-        if (tileIsType(tagpro.map[xt][yt], tileNameArray[i])) {
+        if (tileHasName(tagpro.map[xt][yt], tileNameArray[i])) {
           return { x: xt * PPTL, y: yt * PPTL };
         }
       }

--- a/src/helpers/finders.js
+++ b/src/helpers/finders.js
@@ -1,12 +1,13 @@
 import _ from 'lodash';
 
+import { tileIsType } from '../tiles';
 import { isOnMyTeam } from './player';
 import { PPTL } from '../constants';
 import { assert } from '../utils/asserts';
 
 
 /*
- * Returns the position x and y (in pixels) of the first of the specified tile
+ * Returns the position xt and yt (in pixels) of the first of the specified tile
  * types to appear starting in the top left corner and moving in a page-reading
  * fashion.
  *
@@ -15,24 +16,24 @@ import { assert } from '../utils/asserts';
  * @param {(number | number[])} tiles - either a number representing a tileType,
  * or an array of such numbers
  */
-export function findTile(tileIds) {
-  assert(tileIds, 'tileIds is undefined');
+export function findTile(tileNames) {
+  assert(tileNames, 'tileNames is undefined');
   assert(tagpro.map, 'tagpro.map is undefined');
 
   // Force an array if the input is just one tile
-  const tileIdArray = [].concat(tileIds);
+  const tileNameArray = [].concat(tileNames);
 
-  for (let x = 0, xl = tagpro.map.length, yl = tagpro.map[0].length; x < xl; x++) {
-    for (let y = 0; y < yl; y++) {
-      for (let i = 0; i < tileIdArray.length; i++) {
-        const tileId = tileIdArray[i];
-        if (tagpro.map[x][y] === tileId) {
-          return { x: x * PPTL, y: y * PPTL };
+  for (let xt = 0, xl = tagpro.map.length; xt < xl; xt++) {
+    for (let yt = 0, yl = tagpro.map[0].length; yt < yl; yt++) {
+      for (let i = 0; i < tileNameArray.length; i++) {
+        if (tileIsType(tagpro.map[xt][yt], tileNameArray[i])) {
+          return { x: xt * PPTL, y: yt * PPTL };
         }
       }
     }
   }
-  throw new Error(`Unable to find tile: ${tileIds}`);
+
+  throw new Error(`Unable to find tile: ${tileNames}`);
 }
 
 

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -75,35 +75,34 @@ export function getTileTraversabilityInCells(tileId) {
     return init2dArray(CPTL, CPTL, 0);
   }
 
-
   // tile is partially traversable
-  const gridTile = init2dArray(CPTL, CPTL, 1);
+  const tile = init2dArray(CPTL, CPTL, 1);
   const midCell = (CPTL - 1.0) / 2.0;
-  for (let i = 0; i < CPTL; i++) {
-    for (let j = 0; j < CPTL; j++) {
+  for (let xc = 0; xc < CPTL; xc++) {
+    for (let yc = 0; yc < CPTL; yc++) {
       if (tileHasProperty(tileId, 'radius')) { // tile is circular
-        const xDiff = Math.max(Math.abs(i - midCell) - 0.5, 0);
-        const yDiff = Math.max(Math.abs(j - midCell) - 0.5, 0);
+        const xDiff = Math.max(Math.abs(xc - midCell) - 0.5, 0);
+        const yDiff = Math.max(Math.abs(yc - midCell) - 0.5, 0);
         const cellDist = Math.sqrt((xDiff * xDiff) + (yDiff * yDiff));
         const pixelDist = cellDist * PPCL;
         if (pixelDist <= getTileProperty(tileId, 'radius')) {
-          gridTile[i][j] = 0;
+          tile[xc][yc] = 0;
         }
       } else { // tile is angled wall
         // eslint-disable-next-line no-lonely-if
-        if (tileHasName(tileId, 'ANGLE_WALL_1') && j - i >= 0) {
-          gridTile[i][j] = 0;
-        } else if (tileHasName(tileId, 'ANGLE_WALL_2') && i + j <= CPTL - 1) {
-          gridTile[i][j] = 0;
-        } else if (tileHasName(tileId, 'ANGLE_WALL_3') && j - i <= 0) {
-          gridTile[i][j] = 0;
-        } else if (tileHasName(tileId, 'ANGLE_WALL_4') && i + j >= CPTL - 1) {
-          gridTile[i][j] = 0;
+        if (tileHasName(tileId, 'ANGLE_WALL_1') && yc - xc >= 0) {
+          tile[xc][yc] = 0;
+        } else if (tileHasName(tileId, 'ANGLE_WALL_2') && xc + yc <= CPTL - 1) {
+          tile[xc][yc] = 0;
+        } else if (tileHasName(tileId, 'ANGLE_WALL_3') && yc - xc <= 0) {
+          tile[xc][yc] = 0;
+        } else if (tileHasName(tileId, 'ANGLE_WALL_4') && xc + yc >= CPTL - 1) {
+          tile[xc][yc] = 0;
         }
       }
     }
   }
-  return gridTile;
+  return tile;
 }
 
 

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { CPTL, PPCL } from '../constants';
 import { assert, assertGridInBounds } from '../utils/asserts';
-import { tileIsType, getTileProperty, tileHasProperty } from '../tiles';
+import { tileHasName, getTileProperty, tileHasProperty } from '../tiles';
 import { updateNTSprites, generatePermanentNTSprites } from '../draw/drawings';
 
 const mapTraversabilityCells = [];
@@ -68,7 +68,8 @@ export function getTileTraversabilityInCells(tileId) {
     const midCell = (CPTL - 1.0) / 2.0;
     for (let i = 0; i < CPTL; i++) {
       for (let j = 0; j < CPTL; j++) {
-        if (tileHasProperty(tileId, 'radius')) { // tile is CNTO
+        // tile is circular non-traversable object
+        if (tileHasProperty(tileId, 'radius')) {
           const xDiff = Math.max(Math.abs(i - midCell) - 0.5, 0);
           const yDiff = Math.max(Math.abs(j - midCell) - 0.5, 0);
           const cellDist = Math.sqrt((xDiff * xDiff) + (yDiff * yDiff));
@@ -76,24 +77,25 @@ export function getTileTraversabilityInCells(tileId) {
           if (pixelDist <= getTileProperty(tileId, 'radius')) {
             gridTile[i][j] = 0;
           }
-        // tile is noncircular and partially nontraversable (this leaves angled walls)
-        } else if (tileIsType(tileId, 'ANGLE_WALL_1')) {
+        // tile is noncircular and partially nontraversable (angled walls)
+        } else if (tileHasName(tileId, 'ANGLE_WALL_1')) {
           if (j - i >= 0) {
             gridTile[i][j] = 0;
           }
-        } else if (tileIsType(tileId, 'ANGLE_WALL_2')) {
+        } else if (tileHasName(tileId, 'ANGLE_WALL_2')) {
           if (i + j <= CPTL - 1) {
             gridTile[i][j] = 0;
           }
-        } else if (tileIsType(tileId, 'ANGLE_WALL_3')) {
+        } else if (tileHasName(tileId, 'ANGLE_WALL_3')) {
           if (j - i <= 0) {
             gridTile[i][j] = 0;
           }
-        } else if (tileIsType(tileId, 'ANGLE_WALL_4')) {
+        } else if (tileHasName(tileId, 'ANGLE_WALL_4')) {
           if (i + j >= CPTL - 1) {
             gridTile[i][j] = 0;
           }
-        } else { // tile is entirely nontraversable
+        // tile is entirely nontraversable
+        } else {
           return init2dArray(CPTL, CPTL, 0);
         }
       }

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { CPTL, PPCL } from '../constants';
 import { assert, assertGridInBounds } from '../utils/asserts';
-import { getTileProperty, tileHasProperty, tileIsType } from '../tiles';
+import { tileIsType, getTileProperty, tileHasProperty } from '../tiles';
 import { updateNTSprites, generatePermanentNTSprites } from '../draw/drawings';
 
 const mapTraversabilityCells = [];
@@ -57,38 +57,39 @@ export function fillGridWithSubgrid(bigGrid, smallGrid, x, y) {
 /* Returns a 2d cell array of traversible (1) and blocked (0) cells inside a tile.
  * Runtime: O(CPTL^2)
  *
- * @param {number} tileID - the ID of the tile that should be split into cells and
- *   parsed for traversability
+ * @param {number} tileId - the id of the tile that should be split into cells and
+ * parsed for traversability
  */
-export function getTileTraversabilityInCells(tileID) {
+export function getTileTraversabilityInCells(tileId) {
   // Start with all cells being traversable
   const gridTile = init2dArray(CPTL, CPTL, 1);
 
-  if (!getTileProperty(tileID, 'traversable')) { // tile is not fully traversable
+  if (!getTileProperty(tileId, 'traversable')) { // tile is not fully traversable
     const midCell = (CPTL - 1.0) / 2.0;
     for (let i = 0; i < CPTL; i++) {
       for (let j = 0; j < CPTL; j++) {
-        if (tileHasProperty(tileID, 'radius')) {
+        if (tileHasProperty(tileId, 'radius')) { // tile is CNTO
           const xDiff = Math.max(Math.abs(i - midCell) - 0.5, 0);
           const yDiff = Math.max(Math.abs(j - midCell) - 0.5, 0);
           const cellDist = Math.sqrt((xDiff * xDiff) + (yDiff * yDiff));
           const pixelDist = cellDist * PPCL;
-          if (pixelDist <= getTileProperty(tileID, 'radius')) {
+          if (pixelDist <= getTileProperty(tileId, 'radius')) {
             gridTile[i][j] = 0;
-          } // tile is noncircular and nontraversable
-        } else if (tileIsType(tileID, 'ANGLE_WALL_1')) {
+          }
+        // tile is noncircular and partially nontraversable (this leaves angled walls)
+        } else if (tileIsType(tileId, 'ANGLE_WALL_1')) {
           if (j - i >= 0) {
             gridTile[i][j] = 0;
           }
-        } else if (tileIsType(tileID, 'ANGLE_WALL_2')) {
+        } else if (tileIsType(tileId, 'ANGLE_WALL_2')) {
           if (i + j <= CPTL - 1) {
             gridTile[i][j] = 0;
           }
-        } else if (tileIsType(tileID, 'ANGLE_WALL_3')) {
+        } else if (tileIsType(tileId, 'ANGLE_WALL_3')) {
           if (j - i <= 0) {
             gridTile[i][j] = 0;
           }
-        } else if (tileIsType(tileID, 'ANGLE_WALL_4')) {
+        } else if (tileIsType(tileId, 'ANGLE_WALL_4')) {
           if (i + j >= CPTL - 1) {
             gridTile[i][j] = 0;
           }
@@ -98,6 +99,7 @@ export function getTileTraversabilityInCells(tileID) {
       }
     }
   }
+
   return gridTile;
 }
 
@@ -118,19 +120,20 @@ export function initMapTraversabilityCells(map) {
   init2dArray(xl * CPTL, yl * CPTL, 0, mapTraversabilityCells);
   for (let x = 0; x < xl; x++) {
     for (let y = 0; y < yl; y++) {
+      const tileId = map[x][y];
       fillGridWithSubgrid(
         mapTraversabilityCells,
-        getTileTraversabilityInCells(map[x][y]),
+        getTileTraversabilityInCells(tileId),
         x * CPTL,
         y * CPTL,
       );
-      if (!getTileProperty(map[x][y], 'permanent')) {
+      if (!getTileProperty(tileId, 'permanent')) {
         tilesToUpdate.push({ x, y });
         tilesToUpdateValues.push(map[x][y]);
-        if (!getTileProperty(map[x][y], 'traversable')) {
+        if (!getTileProperty(tileId, 'traversable')) {
           updateNTSprites(x, y, mapTraversabilityCells);
         }
-      } else if (!getTileProperty(map[x][y], 'traversable')) {
+      } else if (!getTileProperty(tileId, 'traversable')) {
         generatePermanentNTSprites(x, y, mapTraversabilityCells);
       }
     }

--- a/src/helpers/map.js
+++ b/src/helpers/map.js
@@ -120,23 +120,23 @@ export function initMapTraversabilityCells(map) {
   const xl = map.length;
   const yl = map[0].length;
   init2dArray(xl * CPTL, yl * CPTL, 0, mapTraversabilityCells);
-  for (let x = 0; x < xl; x++) {
-    for (let y = 0; y < yl; y++) {
-      const tileId = map[x][y];
+  for (let xt = 0; xt < xl; xt++) {
+    for (let yt = 0; yt < yl; yt++) {
+      const tileId = map[xt][yt];
       fillGridWithSubgrid(
         mapTraversabilityCells,
         getTileTraversabilityInCells(tileId),
-        x * CPTL,
-        y * CPTL,
+        xt * CPTL,
+        yt * CPTL,
       );
       if (!getTileProperty(tileId, 'permanent')) {
-        tilesToUpdate.push({ x, y });
-        tilesToUpdateValues.push(map[x][y]);
+        tilesToUpdate.push({ x: xt, y: yt });
+        tilesToUpdateValues.push(tileId);
         if (!getTileProperty(tileId, 'traversable')) {
-          updateNTSprites(x, y, mapTraversabilityCells);
+          updateNTSprites(xt, yt, mapTraversabilityCells);
         }
       } else if (!getTileProperty(tileId, 'traversable')) {
-        generatePermanentNTSprites(x, y, mapTraversabilityCells);
+        generatePermanentNTSprites(xt, yt, mapTraversabilityCells);
       }
     }
   }

--- a/src/helpers/player.js
+++ b/src/helpers/player.js
@@ -1,5 +1,4 @@
 import { teams } from '../constants';
-import { getTileId } from '../tiles';
 
 let me;
 
@@ -24,12 +23,12 @@ export function isOnMyTeam(player) {
   return player.team === me.team;
 }
 
-export function getAllyEndzoneTileId() {
-  return amBlue() ? getTileId('BLUE_ENDZONE') : getTileId('RED_ENDZONE');
+export function getAllyEndzoneTileName() {
+  return amBlue() ? 'BLUE_ENDZONE' : 'RED_ENDZONE';
 }
 
-export function getEnemyEndzoneTileId() {
-  return amBlue() ? getTileId('RED_ENDZONE') : getTileId('BLUE_ENDZONE');
+export function getEnemyEndzoneTileName() {
+  return amBlue() ? 'RED_ENDZONE' : 'BLUE_ENDZONE';
 }
 
 // Returns whether or not ally team's flag is taken

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -3,14 +3,14 @@ import { assert } from './utils/asserts';
 import { amBlue, amRed } from './helpers/player';
 
 
-const tileInfo = {};
-const tileNames = {};
+const tileInfo = {}; // map from name to properties
+const tileNames = {}; // map from id to name
 
 /*
  * Stores all information we need about tiles in the tileInfo object, and creates the tileNames
  * object so that we can quickly map from an id to a name. This function depends on amBlue and
  * amRed, so the current player must be defined. We call this function once, after our player has an
- * id.
+ * id. All tile ids are stored as the data type they are in the tagpro api. 
  */
 export function computeTileInfo() {
   assert(_.isEmpty(tileInfo), 'tileInfo is not an empty object');
@@ -24,9 +24,9 @@ export function computeTileInfo() {
     ANGLE_WALL_4: { id: 1.4, traversable: false, permanent: true },
     REGULAR_FLOOR: { id: 2, traversable: true, permanent: true },
     RED_FLAG: { id: 3, traversable: true, permanent: false },
-    RED_FLAG_TAKEN: { id: 3.1, traversable: true, permanent: false },
+    RED_FLAG_TAKEN: { id: '3.1', traversable: true, permanent: false },
     BLUE_FLAG: { id: 4, traversable: true, permanent: false },
-    BLUE_FLAG_TAKEN: { id: 4.1, traversable: true, permanent: false },
+    BLUE_FLAG_TAKEN: { id: '4.1', traversable: true, permanent: false },
     SPEEDPAD_ACTIVE: { id: 5, traversable: false, radius: 15, permanent: false },
     SPEEDPAD_INACTIVE: { id: '5.1', traversable: true, permanent: false },
     POWERUP_SUBGROUP: { id: 6, traversable: false, radius: 15, permanent: false },
@@ -47,9 +47,9 @@ export function computeTileInfo() {
     ACTIVE_PORTAL: { id: 13, traversable: false, radius: 15, permanent: false },
     INACTIVE_PORTAL: { id: '13.1', traversable: true, permanent: false },
     SPEEDPAD_RED_ACTIVE: { id: 14, traversable: false, radius: 15, permanent: false },
-    SPEEDPAD_RED_INACTIVE: { id: 14.1, traversable: true, permanent: false },
+    SPEEDPAD_RED_INACTIVE: { id: '14.1', traversable: true, permanent: false },
     SPEEDPAD_BLUE_ACTIVE: { id: 15, traversable: false, radius: 15, permanent: false },
-    SPEEDPAD_BLUE_INACTIVE: { id: 15.1, traversable: true, permanent: false },
+    SPEEDPAD_BLUE_INACTIVE: { id: '15.1', traversable: true, permanent: false },
     YELLOW_FLAG: { id: 16, traversable: true, permanent: false },
     YELLOW_FLAG_TAKEN: { id: '16.1', traversable: true, permanent: false },
     RED_ENDZONE: { id: 17, traversable: true, permanent: true },
@@ -67,35 +67,10 @@ export function computeTileInfo() {
 
 
 /*
- * @param {number} tileID - the ID of the tile
- * @param {String} property - the name of a property
- * @return {boolean} if the corresponding tile has a value for this property
- */
-export function tileHasProperty(tileID, property) {
-  const tileIDString = String(tileID);
-  assert(_.has(tileNames, tileIDString), `Unknown tileID: ${tileID}`);
-  const tileName = tileNames[tileID];
-  return _.has(tileInfo[tileName], property);
-}
-
-
-/*
- * @param {number} tileID - the ID of the tile whose property we want
- * @param {String} property - the name of a property stored in tileInfo
- * @return the property for the input tile
- */
-export function getTileProperty(tileID, property) {
-  assert(tileHasProperty(tileID, property), `Unknown property for tile: ${tileID}, ${property}`);
-  const tileName = tileNames[tileID];
-  return tileInfo[tileName][property];
-}
-
-
-/*
  * @param {String} name - the name of a tile
- * @return the id for the input tile name
+ * @return {(number|String)} the id for the input tile name
  */
-export function getTileId(name) {
+function getTileId(name) {
   assert(_.has(tileInfo, name), `Unknown tileName: ${name}`);
   return tileInfo[name].id;
 }
@@ -104,8 +79,44 @@ export function getTileId(name) {
 /*
  * @param {number} tileID - the id for a tile
  * @param {String} name - the name of a tile
- * @return true if tileId is the id of the named tile
+ * @return true if tileId is the id of the named tile, using a type-sensative comparison
  */
 export function tileIsType(tileId, name) {
   return getTileId(name) === tileId;
 }
+
+/*
+ * @param {(number|String)} tileId - the id of a tile
+ * @return {String} the name for the input tile id
+ */
+function getTileName(tileId) {
+  assert(_.has(tileNames, tileId), `Unknown tileId: ${tileId}`);
+  const name = tileNames[tileId];
+  assert(tileIsType(tileId, name), `Input id:${tileId} was wrong data type.`);
+  return name;
+}
+
+
+/*
+ * @param {String} tileId - the id of the tile
+ * @param {String} property - the name of a property
+ * @return {boolean} if the corresponding tile has a value for this property
+ */
+export function tileHasProperty(tileId, property) {
+  const name = getTileName(tileId);
+  return _.has(tileInfo[name], property);
+}
+
+
+/*
+ * @param {String} tileId - the id of the tile whose property we want
+ * @param {String} property - the name of a property stored in tileInfo
+ * @return the property for the input tile
+ */
+export function getTileProperty(tileId, property) {
+  const name = getTileName(tileId);
+  assert(tileHasProperty(tileId, property),
+    `Tile does not have property: ${name}, ${property}`);
+  return tileInfo[name][property];
+}
+

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -67,56 +67,49 @@ export function computeTileInfo() {
 
 
 /*
- * @param {String} name - the name of a tile
- * @return {(number|String)} the id for the input tile name
- */
-function getTileId(name) {
-  assert(_.has(tileInfo, name), `Unknown tileName: ${name}`);
-  return tileInfo[name].id;
-}
-
-
-/*
  * @param {number} tileID - the id for a tile
  * @param {String} name - the name of a tile
- * @return true if tileId is the id of the named tile, using a type-sensative comparison
+ * @return true if id is the id of the named tile, using a type-sensitive comparison
  */
-export function tileIsType(tileId, name) {
-  return getTileId(name) === tileId;
+export function tileHasName(id, name) {
+  assert(_.has(tileInfo, name), `Unknown tileName: ${name}`);
+  return tileInfo[name].id === id;
 }
 
 /*
- * @param {(number|String)} tileId - the id of a tile
+ * @param {(number|String)} id - the id of a tile
  * @return {String} the name for the input tile id
  */
-function getTileName(tileId) {
-  assert(_.has(tileNames, tileId), `Unknown tileId: ${tileId}`);
-  const name = tileNames[tileId];
-  assert(tileIsType(tileId, name), `Input id:${tileId} was wrong data type.`);
+function getTileName(id) {
+  assert(_.has(tileNames, id), `Unknown id: ${id}`);
+  const name = tileNames[id];
+  assert(tileHasName(id, name), `Input id:${id} was wrong data type.`);
   return name;
 }
 
 
 /*
- * @param {String} tileId - the id of the tile
+ * @param {String} id - the id of the tile
  * @param {String} property - the name of a property
  * @return {boolean} if the corresponding tile has a value for this property
  */
-export function tileHasProperty(tileId, property) {
-  const name = getTileName(tileId);
+export function tileHasProperty(id, property) {
+  const name = getTileName(id);
   return _.has(tileInfo[name], property);
 }
 
 
 /*
- * @param {String} tileId - the id of the tile whose property we want
+ * @param {String} id - the id of the tile whose property we want
  * @param {String} property - the name of a property stored in tileInfo
  * @return the property for the input tile
  */
-export function getTileProperty(tileId, property) {
-  const name = getTileName(tileId);
-  assert(tileHasProperty(tileId, property),
-    `Tile does not have property: ${name}, ${property}`);
+export function getTileProperty(id, property) {
+  const name = getTileName(id);
+  assert(
+    tileHasProperty(id, property),
+    `Tile does not have property: ${name}, ${property}`,
+  );
   return tileInfo[name][property];
 }
 

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -10,7 +10,7 @@ const tileNames = {}; // map from id to name
  * Stores all information we need about tiles in the tileInfo object, and creates the tileNames
  * object so that we can quickly map from an id to a name. This function depends on amBlue and
  * amRed, so the current player must be defined. We call this function once, after our player has an
- * id. All tile ids are stored as the data type they are in the tagpro api. 
+ * id. All tile ids are stored as the data type they are in the tagpro api.
  */
 export function computeTileInfo() {
   assert(_.isEmpty(tileInfo), 'tileInfo is not an empty object');
@@ -67,7 +67,7 @@ export function computeTileInfo() {
 
 
 /*
- * @param {number} tileID - the id for a tile
+ * @param {number} id - the id for a tile
  * @param {String} name - the name of a tile
  * @return true if id is the id of the named tile, using a type-sensitive comparison
  */
@@ -102,7 +102,7 @@ export function tileHasProperty(id, property) {
 /*
  * @param {String} id - the id of the tile whose property we want
  * @param {String} property - the name of a property stored in tileInfo
- * @return the property for the input tile
+ * @return {(number|String|boolean)} the property for the input tile
  */
 export function getTileProperty(id, property) {
   const name = getTileName(id);
@@ -113,3 +113,17 @@ export function getTileProperty(id, property) {
   return tileInfo[name][property];
 }
 
+
+/*
+ * @param {String} id - the id of the tile
+ * @param {String[]} names - an array of tile names
+ * @return {boolean} if the tile with the corresponding id's name is in names
+ */
+export function tileIsOneOf(id, names) {
+  for (let i = 0; i < names.length; i++) {
+    if (tileHasName(id, names[i])) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/test/helpers/finders.spec.js
+++ b/test/helpers/finders.spec.js
@@ -25,9 +25,9 @@ test('findTile: returns correctly with orthogonal inputs', t => {
   };
   /* eslint-enable no-multi-spaces, array-bracket-spacing */
 
-  t.same(findTile(bomb), { x: 0 * PPTL, y: 0 * PPTL });
-  t.same(findTile(redgate), { x: 0 * PPTL, y: 2 * PPTL });
-  t.same(findTile(spike), { x: 2 * PPTL, y: 1 * PPTL });
+  t.same(findTile('BOMB'), { x: 0 * PPTL, y: 0 * PPTL });
+  t.same(findTile('RED_GATE'), { x: 0 * PPTL, y: 2 * PPTL });
+  t.same(findTile('SPIKE'), { x: 2 * PPTL, y: 1 * PPTL });
 
   teardownTiles();
 

--- a/test/helpers/finders.spec.js
+++ b/test/helpers/finders.spec.js
@@ -1,7 +1,6 @@
 import test from 'tape';
 import { findTile } from '../../src/helpers/finders';
 import { setupTiles, teardownTiles } from '../tiles.spec';
-import { getTileId } from '../../src/tiles';
 import { teams, PPTL } from '../../src/constants';
 
 
@@ -9,20 +8,21 @@ test('findTile: returns correctly with orthogonal inputs', t => {
   setupTiles(teams.BLUE);
 
   // create a dummy map from bombs, spikes, gates, and regular tiles
-  const bomb = getTileId('BOMB');
-  const spike = getTileId('SPIKE');
-  const redgate = getTileId('RED_GATE');
-  const bluegate = getTileId('BLUE_GATE');
-  const blank = getTileId('REGULAR_FLOOR');
+  const bomb = 10;
+  const spike = 7;
+  const redGate = 9.2;
+  const blueGate = 9.3;
+  const floor = 2;
 
   /* eslint-disable no-multi-spaces, array-bracket-spacing */
   global.tagpro = {
     map: [
-      [bomb,    blank,    redgate],
-      [redgate, bluegate, blank  ],
-      [blank,   spike,    bomb   ],
+      [bomb,    floor,    redGate],
+      [redGate, blueGate, floor  ],
+      [floor,   spike,    bomb   ],
     ],
   };
+
   /* eslint-enable no-multi-spaces, array-bracket-spacing */
 
   t.same(findTile('BOMB'), { x: 0 * PPTL, y: 0 * PPTL });

--- a/test/helpers/map.spec.js
+++ b/test/helpers/map.spec.js
@@ -10,7 +10,6 @@ import {
 } from '../../src/helpers/map';
 import { setupTiles, teardownTiles } from '../tiles.spec';
 import { teams } from '../../src/constants';
-import { getTileId } from '../../src/tiles';
 
 
 test('init2dArray: returns 2d array that is correct size, and with correct value filled in', t => {
@@ -104,7 +103,7 @@ test('getTileTraversabilityInCells() ', tester => {
     setupTiles(teams.BLUE);
     MapRewireAPI.__Rewire__('CPTL', 1);
     MapRewireAPI.__Rewire__('PPCL', 40);
-    t.same(getTileTraversabilityInCells(getTileId('REGULAR_FLOOR')), [
+    t.same(getTileTraversabilityInCells(2), [ // regular floor
       [1],
     ]);
 
@@ -120,7 +119,7 @@ test('getTileTraversabilityInCells() ', tester => {
     setupTiles(teams.BLUE);
     MapRewireAPI.__Rewire__('CPTL', 1);
     MapRewireAPI.__Rewire__('PPCL', 40);
-    t.same(getTileTraversabilityInCells(getTileId('SQUARE_WALL')), [
+    t.same(getTileTraversabilityInCells(1), [ // square wall
       [0],
     ]);
 
@@ -136,7 +135,7 @@ test('getTileTraversabilityInCells() ', tester => {
     setupTiles(teams.BLUE);
     MapRewireAPI.__Rewire__('CPTL', 4);
     MapRewireAPI.__Rewire__('PPCL', 10);
-    t.same(getTileTraversabilityInCells(getTileId('INACTIVE_PORTAL')), [
+    t.same(getTileTraversabilityInCells('13.1'), [ // inactive portal
       [1, 1, 1, 1],
       [1, 1, 1, 1],
       [1, 1, 1, 1],
@@ -155,7 +154,7 @@ test('getTileTraversabilityInCells() ', tester => {
     MapRewireAPI.__Rewire__('CPTL', 4);
     MapRewireAPI.__Rewire__('PPCL', 10);
     setupTiles(teams.BLUE);
-    t.same(getTileTraversabilityInCells(getTileId('SPIKE')), [
+    t.same(getTileTraversabilityInCells(7), [ // spike
       [1, 0, 0, 1],
       [0, 0, 0, 0],
       [0, 0, 0, 0],
@@ -174,7 +173,7 @@ test('getTileTraversabilityInCells() ', tester => {
     MapRewireAPI.__Rewire__('CPTL', 4);
     MapRewireAPI.__Rewire__('PPCL', 10);
     setupTiles(teams.BLUE);
-    t.same(getTileTraversabilityInCells(getTileId('ACTIVE_PORTAL')), [
+    t.same(getTileTraversabilityInCells(13), [ // active portal
       [0, 0, 0, 0],
       [0, 0, 0, 0],
       [0, 0, 0, 0],
@@ -192,7 +191,7 @@ test('getTileTraversabilityInCells() ', tester => {
   tester.test('returns correctly with angled wall 1, CPTL=4', t => {
     MapRewireAPI.__Rewire__('CPTL', 4);
     setupTiles(teams.BLUE);
-    t.same(getTileTraversabilityInCells(getTileId('ANGLE_WALL_1')), [
+    t.same(getTileTraversabilityInCells(1.1), [ // angle wall 1
       [0, 0, 0, 0],
       [1, 0, 0, 0],
       [1, 1, 0, 0],
@@ -209,7 +208,7 @@ test('getTileTraversabilityInCells() ', tester => {
   tester.test('returns correctly with angled wall 2, CPTL=4', t => {
     MapRewireAPI.__Rewire__('CPTL', 4);
     setupTiles(teams.BLUE);
-    t.same(getTileTraversabilityInCells(getTileId('ANGLE_WALL_2')), [
+    t.same(getTileTraversabilityInCells(1.2), [ // angle wall 2
       [0, 0, 0, 0],
       [0, 0, 0, 1],
       [0, 0, 1, 1],
@@ -226,7 +225,7 @@ test('getTileTraversabilityInCells() ', tester => {
   tester.test('returns correctly with angled wall 3, CPTL=4', t => {
     MapRewireAPI.__Rewire__('CPTL', 4);
     setupTiles(teams.BLUE);
-    t.same(getTileTraversabilityInCells(getTileId('ANGLE_WALL_3')), [
+    t.same(getTileTraversabilityInCells(1.3), [ // angle wall 3
       [0, 1, 1, 1],
       [0, 0, 1, 1],
       [0, 0, 0, 1],
@@ -243,7 +242,7 @@ test('getTileTraversabilityInCells() ', tester => {
   tester.test('returns correctly with angled wall 4, CPTL=4', t => {
     MapRewireAPI.__Rewire__('CPTL', 4);
     setupTiles(teams.BLUE);
-    t.same(getTileTraversabilityInCells(getTileId('ANGLE_WALL_4')), [
+    t.same(getTileTraversabilityInCells(1.4), [ // angle wall 4
       [1, 1, 1, 0],
       [1, 1, 0, 0],
       [1, 0, 0, 0],
@@ -261,7 +260,7 @@ test('getTileTraversabilityInCells() ', tester => {
     setupTiles(teams.BLUE);
     MapRewireAPI.__Rewire__('CPTL', 8);
     MapRewireAPI.__Rewire__('PPCL', 5);
-    t.same(getTileTraversabilityInCells(getTileId('BUTTON')), [
+    t.same(getTileTraversabilityInCells(8), [ // button
       [1, 1, 1, 1, 1, 1, 1, 1],
       [1, 1, 1, 1, 1, 1, 1, 1],
       [1, 1, 0, 0, 0, 0, 1, 1],
@@ -276,7 +275,7 @@ test('getTileTraversabilityInCells() ', tester => {
 
     MapRewireAPI.__Rewire__('CPTL', 8);
     MapRewireAPI.__Rewire__('PPCL', 5);
-    t.same(getTileTraversabilityInCells(getTileId('SPIKE')), [
+    t.same(getTileTraversabilityInCells(7), [ // spike
       [1, 1, 1, 1, 1, 1, 1, 1],
       [1, 1, 0, 0, 0, 0, 1, 1],
       [1, 0, 0, 0, 0, 0, 0, 1],
@@ -315,12 +314,12 @@ test('getMapTraversabilityInCells: returns correctly with CPTL=1', t => {
   setupTiles(teams.BLUE);
   MapRewireAPI.__Rewire__('CPTL', 1);
   // create a dummy map from bombs, spikes, gates, and regular tiles
-  const bomb = getTileId('BOMB');
-  const inactivebomb = getTileId('INACTIVE_BOMB');
-  const spike = getTileId('SPIKE');
-  const redgate = getTileId('RED_GATE');
-  const bluegate = getTileId('BLUE_GATE');
-  const blank = getTileId('REGULAR_FLOOR');
+  const bomb = 10;
+  const inactivebomb = '10.1';
+  const spike = 7;
+  const redgate = 9.2;
+  const bluegate = 9.3;
+  const blank = 2;
 
   const mockTilesToUpdateValues = [bomb, redgate, redgate, bluegate, bomb];
   MapRewireAPI.__Rewire__('mapTraversabilityCells', [
@@ -394,12 +393,12 @@ test('getMapTraversabilityInCells: returns correctly with CPTL=1', t => {
 test('getMapTraversabilityInCells: returns correctly with CPTL=2', t => {
   setupTiles(teams.RED);
   // create a dummy map from bombs, spikes, gates, and regular tiles
-  const bomb = getTileId('BOMB');
-  const inactivebomb = getTileId('INACTIVE_BOMB');
-  const spike = getTileId('SPIKE');
-  const redgate = getTileId('RED_GATE');
-  const bluegate = getTileId('BLUE_GATE');
-  const blank = getTileId('REGULAR_FLOOR');
+  const bomb = 10;
+  const inactivebomb = '10.1';
+  const spike = 7;
+  const redgate = 9.2;
+  const bluegate = 9.3;
+  const blank = 2;
 
   let mockTilesToUpdateValues = [inactivebomb, redgate, bluegate, redgate, bomb];
   MapRewireAPI.__Rewire__('mapTraversabilityCells', [
@@ -497,11 +496,11 @@ test('initMapTraversabilityCells()', tester => {
     setupTiles(teams.BLUE);
     MapRewireAPI.__Rewire__('CPTL', 1);
     // create a dummy map from bombs, spikes, gates, and regular tiles
-    const bomb = getTileId('BOMB');
-    const spike = getTileId('SPIKE');
-    const redgate = getTileId('RED_GATE');
-    const bluegate = getTileId('BLUE_GATE');
-    const blank = getTileId('REGULAR_FLOOR');
+    const bomb = 10;
+    const spike = 7;
+    const redgate = 9.2;
+    const bluegate = 9.3;
+    const blank = 2;
 
     const mockMapTraversabilityCells = [];
     const mockTilesToUpdate = [];

--- a/test/tiles.spec.js
+++ b/test/tiles.spec.js
@@ -9,8 +9,8 @@ import _ from 'lodash';
 import {
   computeTileInfo,
   getTileProperty,
+  tileHasName,
   tileHasProperty,
-  tileIsType,
   __RewireAPI__ as TileRewireAPI,
 } from '../src/tiles';
 import { teams } from '../src/constants';
@@ -120,7 +120,7 @@ test('getTileProperty: throws error given tileIds that don\'t exist', t => {
   t.throws(() => { getTileProperty(1.123, 'traversable'); });
   t.throws(() => { getTileProperty(-1, 'traversable'); });
   t.throws(() => { getTileProperty('potato', 'traversable'); });
-  t.throws(() => { getTileProperty('NONEXISTANT_TILE', 'traversable'); });
+  t.throws(() => { getTileProperty('NONEXISTENT_TILE', 'traversable'); });
   teardownTiles();
 
   t.end();
@@ -171,39 +171,39 @@ test('tileHasProperty: throws error when input id is wrong data type', t => {
 });
 
 
-test('tileIsType: returns true when tileId and name match', t => {
+test('tileHasName: returns true when tileId and name match', t => {
   setupTiles(teams.BLUE);
-  t.ok(tileIsType(1.1, 'ANGLE_WALL_1'));
-  t.ok(tileIsType(4, 'BLUE_FLAG'));
-  t.ok(tileIsType('5.1', 'SPEEDPAD_INACTIVE'));
-  t.ok(tileIsType('16.1', 'YELLOW_FLAG_TAKEN'));
-  t.ok(tileIsType(18, 'BLUE_ENDZONE'));
+  t.ok(tileHasName(1.1, 'ANGLE_WALL_1'));
+  t.ok(tileHasName(4, 'BLUE_FLAG'));
+  t.ok(tileHasName('5.1', 'SPEEDPAD_INACTIVE'));
+  t.ok(tileHasName('16.1', 'YELLOW_FLAG_TAKEN'));
+  t.ok(tileHasName(18, 'BLUE_ENDZONE'));
   teardownTiles();
 
   t.end();
 });
 
 
-test('tileIsType: returns false when tileId and name do not match', t => {
+test('tileHasName: returns false when tileId and name do not match', t => {
   setupTiles(teams.BLUE);
-  t.notOk(tileIsType(1, 'ANGLE_WALL_1'));
-  t.notOk(tileIsType(4, 'RED_FLAG'));
-  t.notOk(tileIsType(5.1, 'SPEEDPAD_INACTIVE'));
-  t.notOk(tileIsType('16', 'YELLOW_FLAG_TAKEN'));
-  t.notOk(tileIsType(17, 'BLUE_ENDZONE'));
+  t.notOk(tileHasName(1, 'ANGLE_WALL_1'));
+  t.notOk(tileHasName(4, 'RED_FLAG'));
+  t.notOk(tileHasName(5.1, 'SPEEDPAD_INACTIVE'));
+  t.notOk(tileHasName('16', 'YELLOW_FLAG_TAKEN'));
+  t.notOk(tileHasName(17, 'BLUE_ENDZONE'));
   teardownTiles();
 
   t.end();
 });
 
 
-test('tileIsType: errors when name is not a tile', t => {
+test('tileHasName: errors when name is not a tile', t => {
   setupTiles(teams.BLUE);
-  t.throws(() => { tileIsType(1, undefined); });
-  t.throws(() => { tileIsType(1, 'potato'); });
-  t.throws(() => { tileIsType(1, 'toid'); });
-  t.throws(() => { tileIsType(1, ''); });
-  t.throws(() => { tileIsType(1, 1); });
+  t.throws(() => { tileHasName(1, undefined); });
+  t.throws(() => { tileHasName(1, 'potato'); });
+  t.throws(() => { tileHasName(1, 'toid'); });
+  t.throws(() => { tileHasName(1, ''); });
+  t.throws(() => { tileHasName(1, 1); });
   teardownTiles();
 
   t.end();

--- a/test/tiles.spec.js
+++ b/test/tiles.spec.js
@@ -9,8 +9,8 @@ import _ from 'lodash';
 import {
   computeTileInfo,
   getTileProperty,
-  tileIsType,
   tileHasProperty,
+  tileIsType,
   __RewireAPI__ as TileRewireAPI,
 } from '../src/tiles';
 import { teams } from '../src/constants';
@@ -32,9 +32,9 @@ export function setupTiles(teamColor) {
     ANGLE_WALL_4: { id: 1.4, traversable: false, permanent: true },
     REGULAR_FLOOR: { id: 2, traversable: true, permanent: true },
     RED_FLAG: { id: 3, traversable: true, permanent: false },
-    RED_FLAG_TAKEN: { id: 3.1, traversable: true, permanent: false },
+    RED_FLAG_TAKEN: { id: '3.1', traversable: true, permanent: false },
     BLUE_FLAG: { id: 4, traversable: true, permanent: false },
-    BLUE_FLAG_TAKEN: { id: 4.1, traversable: true, permanent: false },
+    BLUE_FLAG_TAKEN: { id: '4.1', traversable: true, permanent: false },
     SPEEDPAD_ACTIVE: { id: 5, traversable: false, radius: 15, permanent: false },
     SPEEDPAD_INACTIVE: { id: '5.1', traversable: true, permanent: false },
     POWERUP_SUBGROUP: { id: 6, traversable: false, radius: 15, permanent: false },
@@ -55,9 +55,9 @@ export function setupTiles(teamColor) {
     ACTIVE_PORTAL: { id: 13, traversable: false, radius: 15, permanent: false },
     INACTIVE_PORTAL: { id: '13.1', traversable: true, permanent: false },
     SPEEDPAD_RED_ACTIVE: { id: 14, traversable: false, radius: 15, permanent: false },
-    SPEEDPAD_RED_INACTIVE: { id: 14.1, traversable: true, permanent: false },
+    SPEEDPAD_RED_INACTIVE: { id: '14.1', traversable: true, permanent: false },
     SPEEDPAD_BLUE_ACTIVE: { id: 15, traversable: false, radius: 15, permanent: false },
-    SPEEDPAD_BLUE_INACTIVE: { id: 15.1, traversable: true, permanent: false },
+    SPEEDPAD_BLUE_INACTIVE: { id: '15.1', traversable: true, permanent: false },
     YELLOW_FLAG: { id: 16, traversable: true, permanent: false },
     YELLOW_FLAG_TAKEN: { id: '16.1', traversable: true, permanent: false },
     RED_ENDZONE: { id: 17, traversable: true, permanent: true },
@@ -106,9 +106,9 @@ test('computeTileInfo: stores info in tileInfo', t => {
 
 test('getTileProperty: returns correct properties', t => {
   setupTiles(teams.BLUE);
-  t.is(getTileProperty(1, 'traversable'), false);
-  t.is(getTileProperty(2, 'traversable'), true);
-  t.is(getTileProperty(13, 'radius'), 15);
+  t.is(getTileProperty(1, 'traversable'), false); // square wall
+  t.is(getTileProperty(2, 'traversable'), true); // regular floor
+  t.is(getTileProperty(13, 'radius'), 15); // active portal
   teardownTiles();
 
   t.end();
@@ -120,7 +120,7 @@ test('getTileProperty: throws error given tileIds that don\'t exist', t => {
   t.throws(() => { getTileProperty(1.123, 'traversable'); });
   t.throws(() => { getTileProperty(-1, 'traversable'); });
   t.throws(() => { getTileProperty('potato', 'traversable'); });
-  t.throws(() => { getTileProperty(undefined, 'traversable'); });
+  t.throws(() => { getTileProperty('NONEXISTANT_TILE', 'traversable'); });
   teardownTiles();
 
   t.end();
@@ -129,8 +129,19 @@ test('getTileProperty: throws error given tileIds that don\'t exist', t => {
 
 test('getTileProperty: throws error given properties that don\'t exist', t => {
   setupTiles(teams.BLUE);
-  t.throws(() => { getTileProperty(5, 'potato'); });
-  t.throws(() => { getTileProperty(4.1, 'radius'); });
+  t.throws(() => { getTileProperty(0, 'potato'); });
+  t.throws(() => { getTileProperty('4.1', 'radius'); }); // blue flag taken
+  teardownTiles();
+
+  t.end();
+});
+
+
+test('getTileProperty: throws error when input id is wrong data type', t => {
+  setupTiles(teams.BLUE);
+  t.throws(() => { getTileProperty('1', 'traversable'); });
+  t.throws(() => { getTileProperty('1.1', 'traversable'); });
+  t.throws(() => { getTileProperty(5.1, 'traversable'); });
   teardownTiles();
 
   t.end();
@@ -139,10 +150,21 @@ test('getTileProperty: throws error given properties that don\'t exist', t => {
 
 test('tileHasProperty: checks if a tile has a property', t => {
   setupTiles(teams.BLUE);
-  t.true(tileHasProperty(4.1, 'permanent'));
-  t.true(tileHasProperty(6.1, 'radius'));
-  t.false(tileHasProperty(0, 'radius'));
-  t.false(tileHasProperty(1, 'radius'));
+  t.true(tileHasProperty('4.1', 'permanent')); // blue flag taken
+  t.true(tileHasProperty(6.1, 'radius')); // juke juice
+  t.false(tileHasProperty(0, 'radius')); // empty space
+  t.false(tileHasProperty(2, 'radius')); // regular floor
+  teardownTiles();
+
+  t.end();
+});
+
+
+test('tileHasProperty: throws error when input id is wrong data type', t => {
+  setupTiles(teams.BLUE);
+  t.throws(() => { tileHasProperty('1', 'traversable'); });
+  t.throws(() => { tileHasProperty('1.1', 'traversable'); });
+  t.throws(() => { tileHasProperty(5.1, 'traversable'); });
   teardownTiles();
 
   t.end();

--- a/test/tiles.spec.js
+++ b/test/tiles.spec.js
@@ -11,6 +11,7 @@ import {
   getTileProperty,
   tileHasName,
   tileHasProperty,
+  tileIsOneOf,
   __RewireAPI__ as TileRewireAPI,
 } from '../src/tiles';
 import { teams } from '../src/constants';
@@ -204,6 +205,28 @@ test('tileHasName: errors when name is not a tile', t => {
   t.throws(() => { tileHasName(1, 'toid'); });
   t.throws(() => { tileHasName(1, ''); });
   t.throws(() => { tileHasName(1, 1); });
+  teardownTiles();
+
+  t.end();
+});
+
+
+test('tileIsOneOf: returns true when tile\'s name is in names', t => {
+  setupTiles(teams.BLUE);
+  t.ok(tileIsOneOf(0, ['EMPTY_SPACE', 'SPIKE', 'INACTIVE_PORTAL'])); // empty space
+  t.ok(tileIsOneOf(7, ['EMPTY_SPACE', 'SPIKE', 'INACTIVE_PORTAL'])); // spike
+  t.ok(tileIsOneOf('13.1', ['EMPTY_SPACE', 'SPIKE', 'INACTIVE_PORTAL'])); // inactive_portal
+  teardownTiles();
+
+  t.end();
+});
+
+
+test('tileIsOneOf: returns false when tile\'s name is in names', t => {
+  setupTiles(teams.BLUE);
+  t.notOk(tileIsOneOf(2, ['EMPTY_SPACE', 'SPIKE', 'INACTIVE_PORTAL']));
+  t.notOk(tileIsOneOf(8, ['EMPTY_SPACE', 'SPIKE', 'INACTIVE_PORTAL']));
+  t.notOk(tileIsOneOf(13.1, ['EMPTY_SPACE', 'SPIKE', 'INACTIVE_PORTAL']));
   teardownTiles();
 
   t.end();


### PR DESCRIPTION
closes #131

This PR did some general code cleaning. It made finders return strings instead of ids. We then use `tileIsType` to actually find the location of those tiles, which takes in a string.

All other user-facing tile functions take in the `id`, so no conversion is needed by the user. The main functionality change is that if we ever pass an id that's not the type we have stored in our `tileInfo`, (ie, float when it should be string, or vice versa), the function will throw an error. This will force us to discover the correct id types for the tagpro tiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chauncy-crib/tagprobot/188)
<!-- Reviewable:end -->
