### PR TITLE
243: `drawGraph` errors because edge points are referenced using `point1`, not `p1`

### DIFF
--- a/src/draw/drawings.js
+++ b/src/draw/drawings.js
@@ -328,8 +328,8 @@ function drawGraph(graph, thickness, color) {
 
   _.forEach(graph.getEdges(), edge => {
     graphGraphics
-      .moveTo(edge.point1.x, edge.point1.y)
-      .lineTo(edge.point2.x, edge.point2.y);
+      .moveTo(edge.p1.x, edge.p1.y)
+      .lineTo(edge.p2.x, edge.p2.y);
   });
   _.forEach(graph.getVertices(), vertex => {
     graphGraphics.drawCircle(vertex.x, vertex.y, thickness / 2);


### PR DESCRIPTION
closes #243

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chauncy-crib/tagprobot/244)
<!-- Reviewable:end -->
