### PR TITLE
272: add raw unfiltered test script for travis to run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - node
 script:
 - npm run lint
-- npm test
+- npm run test:raw
 - npm run build:once
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint:fix": "eslint 'src/**/*.js' 'test/**/*.js' --fix",
     "test": "babel-tape-runner \"test/**/*.js\" | tap-difflet --pessimistic",
     "test:o": "babel-tape-runner \"test/**/*.js\" | tap-difflet",
+    "test:raw": "babel-tape-runner \"test/**/*.js\"",
     "build": "webpack --watch",
     "build:once": "webpack"
   },


### PR DESCRIPTION
Closes #272 

This errors was because of the tap-difflet tape output filter we use.  It's a known issue with that package: https://github.com/namuol/tap-difflet/issues/10

My solution was to just make a raw script that doesn't filter the tape output.  Makes travis slightly harder to read if you're checking its output, but you can usually replicate the errors locally with filtering.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chauncy-crib/tagprobot/295)
<!-- Reviewable:end -->
